### PR TITLE
fix(hud): sync hud overlay open state correctly on mount

### DIFF
--- a/src-tauri/src/health.rs
+++ b/src-tauri/src/health.rs
@@ -30,6 +30,7 @@ pub struct HealthFactor {
     pub evidence: String,
 }
 
+
 #[derive(Serialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct HealthCategory {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1065,6 +1065,7 @@ pub fn run() {
             set_hud_click_through,
             set_hud_compact,
             hud_is_compact,
+            hud_is_open,
             close_hud_overlay,
             read_avatar,
             clear_avatar,
@@ -1731,6 +1732,12 @@ fn set_hud_compact(app: tauri::AppHandle, compact: bool) -> Result<(), String> {
 ///
 /// The window is created at the right size already; the page needs the same
 /// answer to lay itself out to match.
+#[tauri::command(async)]
+fn hud_is_open(app: tauri::AppHandle) -> bool {
+    use tauri::Manager;
+    app.get_webview_window("hud").is_some()
+}
+
 #[tauri::command(async)]
 fn hud_is_compact(app: tauri::AppHandle) -> Result<bool, String> {
     Ok(hud_window::read_placement(&store_for_dir(&app)?).compact)

--- a/src/components/pro.tsx
+++ b/src/components/pro.tsx
@@ -376,6 +376,26 @@ export function GamingHudCard({
   // what the state is rather than assuming it starts off.
   useEffect(() => {
     let alive = true;
+
+    // Check if the HUD window is already open (e.g. from a previous session
+    // when we navigate back to this screen)
+    void invoke<boolean>("hud_is_open")
+      .then(async (isOpen) => {
+        if (!alive) return;
+        setOpen(isOpen);
+        if (isOpen) {
+          try {
+            const isCompact = await invoke<boolean>("hud_is_compact");
+            if (alive) setCompact(isCompact);
+          } catch {
+            // The overlay is still known to be open even if its size could
+            // not be read; falling back to the normal layout is the safe
+            // guess, and the size button lets the user correct it.
+          }
+        }
+      })
+      .catch(() => {});
+
     void invoke<{ running: boolean; elevated: boolean }>("fps_status")
       .then((st) => {
         if (!alive) return;


### PR DESCRIPTION
Fixes an issue where `GamingHudCard` assumed the overlay window was closed on mount, causing an inconsistency if the overlay was already open.

---
*PR created automatically by Jules for task [11569442137014876495](https://jules.google.com/task/11569442137014876495) started by @AurelioAvila*