### PR TITLE
Add plain-text account and recovery emails

### DIFF
--- a/backend/src/emails/account.ts
+++ b/backend/src/emails/account.ts
@@ -20,6 +20,22 @@ import { bulletRow, emailShell } from "./layout";
 
 const ACCENT = "#ff5500";
 
+export function verificationText(link: string): string {
+  return `Confirm your email for PC Tweaker\n\nConfirm this address to activate your account:\n${link}\n\nThis link expires in 24 hours. If you did not create this account, ignore this message.`;
+}
+
+export function passwordResetText(link: string): string {
+  return `Reset your PC Tweaker password\n\nChoose a new password:\n${link}\n\nThis link works once and expires in one hour. If you did not request this, ignore this message. Your password stays unchanged.`;
+}
+
+export function passwordChangedText(when: string): string {
+  return `Your PC Tweaker password was changed on ${when}. Every device that was signed in has been signed out.\n\nIf this was not you, request a new reset link from the app immediately and contact support: https://pctweaker.app/support\n\nWe will never ask you for your password by email.`;
+}
+
+export function accountWelcomeText(freeTweakCount: number): string {
+  return `Your PC Tweaker account is ready\n\nYour email is confirmed. Sign in from the app to get started.\n\nYour free account includes ${freeTweakCount} tweaks, live processor, memory and disk monitoring, a startup manager, temporary file cleanup and a password breach check.\n\nOpen PC Tweaker: https://pctweaker.app\nSupport: https://pctweaker.app/support`;
+}
+
 /** The URL under the button, shown so it can be read rather than trusted. */
 function linkFallback(link: string): string {
   return `

--- a/backend/src/mailer.ts
+++ b/backend/src/mailer.ts
@@ -49,9 +49,9 @@ class MailError extends Error {
  * hitting reply, without the sender ever becoming the From address — which
  * would fail SPF/DKIM for a domain we don't own and land the mail in spam.
  */
-type MailInput = { to: string; subject: string; html: string; replyTo?: string };
+type MailInput = { to: string; subject: string; html: string; text?: string; replyTo?: string };
 
-async function sendViaResend({ to, subject, html, replyTo }: MailInput): Promise<void> {
+async function sendViaResend({ to, subject, html, text, replyTo }: MailInput): Promise<void> {
   const res = await fetch("https://api.resend.com/emails", {
     method: "POST",
     signal: AbortSignal.timeout(30_000),
@@ -64,6 +64,7 @@ async function sendViaResend({ to, subject, html, replyTo }: MailInput): Promise
       to,
       subject,
       html,
+      ...(text ? { text } : {}),
       ...(replyTo ? { reply_to: replyTo } : {}),
     }),
   });
@@ -86,9 +87,9 @@ async function sendViaResend({ to, subject, html, replyTo }: MailInput): Promise
  * bodies to logs because they can contain password-reset tokens or personal
  * support content.
  */
-async function sendMail({ to, subject, html, replyTo }: MailInput): Promise<{ delivered: boolean }> {
+async function sendMail({ to, subject, html, text, replyTo }: MailInput): Promise<{ delivered: boolean }> {
   if (useResend) {
-    await sendViaResend({ to, subject, html, replyTo });
+    await sendViaResend({ to, subject, html, text, replyTo });
     return { delivered: true };
   }
   if (transporter) {
@@ -97,6 +98,7 @@ async function sendMail({ to, subject, html, replyTo }: MailInput): Promise<{ de
       to,
       subject,
       html,
+      ...(text ? { text } : {}),
       ...(replyTo ? { replyTo } : {}),
     });
     return { delivered: true };

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -5,6 +5,10 @@ import { hashPassword, verifyPassword, signToken, requireAuth, isValidEmail, isV
 import { createActionToken, consumeActionToken } from "../tokens";
 import { sendMail, MailError } from "../mailer";
 import {
+  accountWelcomeText,
+  passwordChangedText,
+  passwordResetText,
+  verificationText,
   accountWelcomeHtml,
   accountWelcomeSubject,
   passwordChangedHtml,
@@ -66,6 +70,7 @@ async function sendVerificationEmail(userId: number, email: string): Promise<boo
     to: email,
     subject: verificationSubject(),
     html: verificationHtml(rows[0]?.first_name ?? "", link),
+    text: verificationText(link),
   });
   return delivered;
 }
@@ -87,6 +92,7 @@ async function sendAccountWelcome(userId: number): Promise<void> {
     to: user.email,
     subject: accountWelcomeSubject(),
     html: accountWelcomeHtml(user.first_name ?? "", FREE_TWEAK_COUNT),
+    text: accountWelcomeText(FREE_TWEAK_COUNT),
   });
 }
 
@@ -110,6 +116,7 @@ async function sendPasswordChangedNotice(userId: number, changedAt: Date): Promi
     to: user.email,
     subject: passwordChangedSubject(),
     html: passwordChangedHtml(user.first_name ?? "", changedAt.toUTCString()),
+    text: passwordChangedText(changedAt.toUTCString()),
   });
 }
 
@@ -337,6 +344,7 @@ router.post("/forgot-password", async (req: Request, res: Response) => {
         to: email.toLowerCase(),
         subject: passwordResetSubject(),
         html: passwordResetHtml(link),
+        text: passwordResetText(link),
       }).catch((err) => console.error("failed to send reset email:", err));
     }
   } catch (err) {

--- a/backend/test/account-emails.test.mjs
+++ b/backend/test/account-emails.test.mjs
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 const {
+  verificationText, passwordResetText, passwordChangedText, accountWelcomeText,
   accountWelcomeHtml,
   accountWelcomeSubject,
   passwordChangedHtml,
@@ -15,6 +16,15 @@ const {
 const WHEN = "Mon, 01 Sep 2026 09:14:00 GMT";
 
 const LINK = "https://api.pctweaker.app/api/auth/verify-email?token=abc&x=1";
+
+test("plain-text messages preserve action URLs, expiry and account details", () => {
+  assert.ok(verificationText(LINK).includes(LINK));
+  assert.match(verificationText(LINK), /24 hours/);
+  assert.ok(passwordResetText(LINK).includes(LINK));
+  assert.match(passwordResetText(LINK), /once.*one hour/);
+  assert.ok(passwordChangedText(WHEN).includes(WHEN));
+  assert.match(accountWelcomeText(27), /27 tweaks/);
+});
 
 test("the confirmation shows the destination as text, after the button", () => {
   // These two messages are the ones phishing imitates, so a reader has to be


### PR DESCRIPTION
Provide English plain-text alternatives for account verification, welcome, reset and password-change messages. Forward text through Resend and SMTP without changing existing callers. Backend build and all 104 tests pass.