### PR TITLE
Harden Windows tool execution and fix startup and driver results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v1.10.1
+
+Security and reliability update for Windows system tools, startup entries and driver update reporting.
+
+- Native tools now use explicit Windows-owned paths instead of executable search paths. Child tool search paths and PowerShell module paths are restricted, and Command Processor AutoRun is disabled for the Windows Update launcher.
+- System Restore loads its library from the Windows system directory only.
+- Fixed startup-entry parsing for Unicode paths that could previously panic or be classified incorrectly.
+- Driver update results now count every requested update that did not install, including download failures, and reject malformed results rather than reporting zero failures.
+
+The original interface, editable profiles, pricing and existing subscription/Lifetime entitlements are unchanged. Official Windows installers are digitally signed by Aurelio Avila. Code signing does not guarantee that every SmartScreen warning disappears.
+
 ## v1.10.0
 
 Ready-to-use Gaming, Study and Work profiles, function-specific tweak icons, and a more compact account menu. Windows installers remain digitally signed by Aurelio Avila.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Annual billing is approximately 51% below twelve monthly payments. Check the app
 
 [Version-specific signing inventory and verification guide](https://github.com/AurelioAvila/.github/blob/master/CODE_SIGNING.md)
 
-**PC Tweaker 1.10.0 is code-signed.** Its Windows application and release installers identify **Aurelio Avila** as publisher, using Certum and a trusted timestamp.
+**PC Tweaker 1.10.1 is code-signed.** Its Windows application and release installers identify **Aurelio Avila** as publisher, using Certum and a trusted timestamp.
 
 Windows Authenticode and Tauri update signatures have different roles. Authenticode identifies the Windows publisher and detects changes after signing. Tauri's update signature verifies update packages.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pc-tweaker-app",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pc-tweaker-app",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pc-tweaker-app",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.10.1",
   "license": "UNLICENSED",
   "type": "module",
   "scripts": {

--- a/site/src/i18n/dictionary.ts
+++ b/site/src/i18n/dictionary.ts
@@ -214,7 +214,7 @@ export const engDictionary: Dictionary = {
     "subBold": "Make deliberate changes. Keep what works.",
     "sub": " Review Windows settings for gaming, privacy and everyday use. See what each tweak changes, save its previous state and restore supported settings when you need to. Start free. No account required.",
     "cta": "Download Free for Windows",
-    "safetyNote": "PC Tweaker 1.10.0 is code-signed. Our signed Windows installers identify Aurelio Avila as the publisher. Older downloads may be unsigned; check the file's Digital Signatures tab. SmartScreen may still show a warning for a new release.",
+    "safetyNote": "PC Tweaker 1.10.1 is code-signed. Our signed Windows installers identify Aurelio Avila as the publisher. Older downloads may be unsigned; check the file's Digital Signatures tab. SmartScreen may still show a warning for a new release.",
     "terminalTitle": "Install with Windows Package Manager",
     "terminalCmd": "winget install --id AurelioAvila.PCTweaker --exact",
     "terminalHint": "# install the official PC Tweaker package",
@@ -514,7 +514,7 @@ export const engDictionary: Dictionary = {
       },
       {
         "q": "Is PC Tweaker code-signed?",
-        "a": "PC Tweaker 1.10.0 ships with Windows application and installer signatures from Aurelio Avila and a trusted timestamp. Older releases may be unsigned. A valid signature identifies the publisher and helps detect changed files. The separate update signature verifies update packages. Neither guarantees performance gains or prevents every SmartScreen prompt."
+        "a": "PC Tweaker 1.10.1 ships with Windows application and installer signatures from Aurelio Avila and a trusted timestamp. Older releases may be unsigned. A valid signature identifies the publisher and helps detect changed files. The separate update signature verifies update packages. Neither guarantees performance gains or prevents every SmartScreen prompt."
       }
     ]
   },

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-app"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-app"
-version = "1.10.0"
+version = "1.10.1"
 description = "Real Windows tweaks with automatic one-click rollback"
 authors = ["Aurelio Avila"]
 license-file = "../LICENSE"

--- a/src-tauri/src/contextmenu.rs
+++ b/src-tauri/src/contextmenu.rs
@@ -147,18 +147,19 @@ fn restart_explorer() {
     use std::os::windows::process::CommandExt;
     const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
-    let killed = std::process::Command::new("taskkill")
-        .args(["/f", "/im", "explorer.exe"])
-        .creation_flags(CREATE_NO_WINDOW)
-        .status();
+    let killed = crate::system_tools::run("taskkill", |tool| {
+        tool.args(["/f", "/im", "explorer.exe"])
+            .creation_flags(CREATE_NO_WINDOW)
+            .status()
+    });
 
     if killed.is_ok() {
         // Windows normally relaunches Explorer on its own; starting it
         // explicitly covers the configurations where it doesn't, and a second
         // instance is not spawned if one is already back up.
-        let _ = std::process::Command::new("explorer.exe")
-            .creation_flags(CREATE_NO_WINDOW)
-            .spawn();
+        let _ = crate::system_tools::run("explorer.exe", |tool| {
+            tool.creation_flags(CREATE_NO_WINDOW).spawn()
+        });
     }
 }
 

--- a/src-tauri/src/diskhealth.rs
+++ b/src-tauri/src/diskhealth.rs
@@ -15,16 +15,16 @@ pub struct DiskHealth {
 mod imp {
     use super::DiskHealth;
     use std::os::windows::process::CommandExt;
-    use std::process::Command;
 
     const CREATE_NO_WINDOW: u32 = 0x08000000;
 
     fn run_ps(script: &str) -> Result<String, String> {
-        let output = Command::new("powershell")
-            .args(["-NoProfile", "-NonInteractive", "-Command", script])
-            .creation_flags(CREATE_NO_WINDOW)
-            .output()
-            .map_err(|e| format!("could not run PowerShell: {}", e))?;
+        let output = crate::system_tools::run("powershell", |tool| {
+            tool.args(["-NoProfile", "-NonInteractive", "-Command", script])
+                .creation_flags(CREATE_NO_WINDOW)
+                .output()
+        })
+        .map_err(|e| format!("could not run PowerShell: {}", e))?;
         if !output.status.success() {
             return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
         }

--- a/src-tauri/src/diskopt.rs
+++ b/src-tauri/src/diskopt.rs
@@ -14,7 +14,6 @@ pub struct DiskOptResult {
 mod imp {
     use super::DiskOptResult;
     use std::os::windows::process::CommandExt;
-    use std::process::Command;
 
     const CREATE_NO_WINDOW: u32 = 0x08000000;
 
@@ -26,11 +25,12 @@ mod imp {
     pub fn optimize(drive: &str) -> Result<DiskOptResult, String> {
         let media = crate::diskinfo::media_type_of(drive);
 
-        let output = Command::new("defrag")
-            .args([drive, "/O", "/H"])
-            .creation_flags(CREATE_NO_WINDOW)
-            .output()
-            .map_err(|e| format!("could not run defrag: {}", e))?;
+        let output = crate::system_tools::run("defrag", |tool| {
+            tool.args([drive, "/O", "/H"])
+                .creation_flags(CREATE_NO_WINDOW)
+                .output()
+        })
+        .map_err(|e| format!("could not run defrag: {}", e))?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();

--- a/src-tauri/src/dns.rs
+++ b/src-tauri/src/dns.rs
@@ -15,11 +15,12 @@ fn run_ps(script: &str) -> Result<String, String> {
     use std::os::windows::process::CommandExt;
     const CREATE_NO_WINDOW: u32 = 0x08000000;
 
-    let output = std::process::Command::new("powershell")
-        .args(["-NoProfile", "-NonInteractive", "-Command", script])
-        .creation_flags(CREATE_NO_WINDOW)
-        .output()
-        .map_err(|e| format!("could not run PowerShell: {}", e))?;
+    let output = crate::system_tools::run("powershell", |tool| {
+        tool.args(["-NoProfile", "-NonInteractive", "-Command", script])
+            .creation_flags(CREATE_NO_WINDOW)
+            .output()
+    })
+    .map_err(|e| format!("could not run PowerShell: {}", e))?;
 
     if !output.status.success() {
         return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());

--- a/src-tauri/src/drivers.rs
+++ b/src-tauri/src/drivers.rs
@@ -70,7 +70,7 @@ pub struct ScanProgress {
 mod imp {
     use super::{DriverAudit, DriverEntry, ScanProgress};
     use std::os::windows::process::CommandExt;
-    use std::process::Command;
+
     use tauri::Emitter;
 
     const CREATE_NO_WINDOW: u32 = 0x08000000;
@@ -88,11 +88,12 @@ mod imp {
     ];
 
     fn run_ps(script: &str) -> Result<String, String> {
-        let output = Command::new("powershell")
-            .args(["-NoProfile", "-NonInteractive", "-Command", script])
-            .creation_flags(CREATE_NO_WINDOW)
-            .output()
-            .map_err(|e| format!("could not run PowerShell: {}", e))?;
+        let output = crate::system_tools::run("powershell", |tool| {
+            tool.args(["-NoProfile", "-NonInteractive", "-Command", script])
+                .creation_flags(CREATE_NO_WINDOW)
+                .output()
+        })
+        .map_err(|e| format!("could not run PowerShell: {}", e))?;
         if !output.status.success() {
             return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
         }
@@ -311,13 +312,14 @@ pub fn driver_audit(app: tauri::AppHandle) -> Result<DriverAudit, String> {
 #[tauri::command(async)]
 pub fn open_windows_update() -> Result<(), String> {
     use std::os::windows::process::CommandExt;
-    use std::process::Command;
-    Command::new("cmd")
-        .args(["/C", "start", "", "ms-settings:windowsupdate"])
-        .creation_flags(0x08000000)
-        .spawn()
-        .map(|_| ())
-        .map_err(|e| format!("could not open Windows Update: {}", e))
+
+    crate::system_tools::run("cmd", |tool| {
+        tool.args(["/C", "start", "", "ms-settings:windowsupdate"])
+            .creation_flags(0x08000000)
+            .spawn()
+    })
+    .map(|_| ())
+    .map_err(|e| format!("could not open Windows Update: {}", e))
 }
 
 /// Whether Windows itself says a restart is pending. Read from the same
@@ -348,15 +350,16 @@ pub fn reboot_pending() -> Result<bool, String> {
 #[tauri::command(async)]
 pub fn reboot_now() -> Result<(), String> {
     use std::os::windows::process::CommandExt;
-    use std::process::Command;
+
     // A short delay lets this command return so the UI can close cleanly
     // instead of being killed mid-frame.
-    Command::new("shutdown")
-        .args(["/r", "/t", "5", "/c", "Restart requested from PC Tweaker"])
-        .creation_flags(0x08000000)
-        .spawn()
-        .map(|_| ())
-        .map_err(|e| format!("could not restart: {}", e))
+    crate::system_tools::run("shutdown", |tool| {
+        tool.args(["/r", "/t", "5", "/c", "Restart requested from PC Tweaker"])
+            .creation_flags(0x08000000)
+            .spawn()
+    })
+    .map(|_| ())
+    .map_err(|e| format!("could not restart: {}", e))
 }
 
 #[cfg(not(windows))]

--- a/src-tauri/src/driverupdate.rs
+++ b/src-tauri/src/driverupdate.rs
@@ -41,12 +41,58 @@ pub struct InstallOutcome {
     pub reboot_required: bool,
 }
 
+#[cfg(any(windows, test))]
+fn parse_install_outcome(raw: &str, requested: usize) -> Result<InstallOutcome, String> {
+    #[derive(Deserialize)]
+    struct ResultFields {
+        installed: usize,
+        reboot: bool,
+    }
+    let result: ResultFields = serde_json::from_str(raw.trim())
+        .map_err(|e| format!("unexpected driver install result: {e}"))?;
+    let failed = requested
+        .checked_sub(result.installed)
+        .ok_or_else(|| "driver install result exceeds the requested update count".to_string())?;
+    Ok(InstallOutcome {
+        installed: result.installed,
+        failed,
+        reboot_required: result.reboot,
+    })
+}
+
+#[cfg(test)]
+mod outcome_tests {
+    use super::*;
+    #[test]
+    fn missing_or_undownloaded_updates_are_not_reported_as_success() {
+        let result =
+            parse_install_outcome(r#"{"installed":1,"failed":0,"reboot":false}"#, 3).unwrap();
+        assert_eq!(result.installed, 1);
+        assert_eq!(result.failed, 2);
+    }
+    #[test]
+    fn malformed_results_do_not_silently_become_zero_failures() {
+        for raw in [
+            "{}",
+            r#"{"installed":1}"#,
+            r#"{"installed":4,"reboot":false}"#,
+            r#"{"installed":-1,"reboot":false}"#,
+        ] {
+            assert!(parse_install_outcome(raw, 3).is_err());
+        }
+        assert!(
+            parse_install_outcome(r#"{"installed":3,"reboot":true}"#, 3)
+                .unwrap()
+                .reboot_required
+        );
+    }
+}
+
 #[cfg(windows)]
 mod imp {
     use super::{InstallOutcome, UpdateSearchResult};
     use base64::Engine as _;
     use std::os::windows::process::CommandExt;
-    use std::process::Command;
 
     const CREATE_NO_WINDOW: u32 = 0x08000000;
 
@@ -56,11 +102,12 @@ mod imp {
     const MICROSOFT_UPDATE_SERVICE: &str = "7971f918-a847-4430-9279-4a52d1efe18d";
 
     fn run_ps(script: &str) -> Result<String, String> {
-        let output = Command::new("powershell")
-            .args(["-NoProfile", "-NonInteractive", "-Command", script])
-            .creation_flags(CREATE_NO_WINDOW)
-            .output()
-            .map_err(|e| format!("could not run PowerShell: {}", e))?;
+        let output = crate::system_tools::run("powershell", |tool| {
+            tool.args(["-NoProfile", "-NonInteractive", "-Command", script])
+                .creation_flags(CREATE_NO_WINDOW)
+                .output()
+        })
+        .map_err(|e| format!("could not run PowerShell: {}", e))?;
         let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
         if !output.status.success() && stdout.is_empty() {
             return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
@@ -193,13 +240,11 @@ mod imp {
         );
 
         let raw = run_ps(&script)?;
-        let v: serde_json::Value = serde_json::from_str(raw.trim())
-            .map_err(|e| format!("unexpected install result: {} ({})", e, raw))?;
-        Ok(InstallOutcome {
-            installed: v.get("installed").and_then(|x| x.as_u64()).unwrap_or(0) as usize,
-            failed: v.get("failed").and_then(|x| x.as_u64()).unwrap_or(0) as usize,
-            reboot_required: v.get("reboot").and_then(|x| x.as_bool()).unwrap_or(false),
-        })
+        let requested = titles
+            .iter()
+            .collect::<std::collections::HashSet<_>>()
+            .len();
+        super::parse_install_outcome(&raw, requested)
     }
 }
 

--- a/src-tauri/src/gpupower.rs
+++ b/src-tauri/src/gpupower.rs
@@ -48,7 +48,6 @@ pub struct GpuPowerInfo {
 mod imp {
     use super::GpuPowerInfo;
     use std::os::windows::process::CommandExt;
-    use std::process::Command;
 
     const CREATE_NO_WINDOW: u32 = 0x08000000;
 
@@ -61,11 +60,10 @@ mod imp {
     }
 
     fn smi(args: &[&str]) -> Option<String> {
-        let out = Command::new("nvidia-smi")
-            .args(args)
-            .creation_flags(CREATE_NO_WINDOW)
-            .output()
-            .ok()?;
+        let out = crate::system_tools::run("nvidia-smi", |tool| {
+            tool.args(args).creation_flags(CREATE_NO_WINDOW).output()
+        })
+        .ok()?;
         if !out.status.success() {
             return None;
         }
@@ -140,11 +138,10 @@ mod imp {
         let clamped_w = watts.clamp(min, max);
 
         let run = |args: &[&str]| -> Result<(), String> {
-            let out = Command::new("nvidia-smi")
-                .args(args)
-                .creation_flags(CREATE_NO_WINDOW)
-                .output()
-                .map_err(|e| format!("could not run nvidia-smi: {}", e))?;
+            let out = crate::system_tools::run("nvidia-smi", |tool| {
+                tool.args(args).creation_flags(CREATE_NO_WINDOW).output()
+            })
+            .map_err(|e| format!("could not run nvidia-smi: {}", e))?;
             if out.status.success() {
                 return Ok(());
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,8 @@ mod browsercleanup;
 mod cleanup;
 mod contextmenu;
 mod cookies;
+#[cfg(windows)]
+mod system_tools;
 // Public so examples/crashprobe.rs can install the real hook and panic for
 // real: whether a panic actually produces a scrubbed report is the one thing
 // a unit test cannot check, because a test that panics is a test that failed.
@@ -940,12 +942,13 @@ fn drift_watch_enabled() -> bool {
     use std::os::windows::process::CommandExt;
     const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
-    std::process::Command::new("schtasks")
-        .args(["/query", "/tn", updatewatch::TASK_NAME])
-        .creation_flags(CREATE_NO_WINDOW)
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+    crate::system_tools::run("schtasks", |tool| {
+        tool.args(["/query", "/tn", updatewatch::TASK_NAME])
+            .creation_flags(CREATE_NO_WINDOW)
+            .output()
+    })
+    .map(|o| o.status.success())
+    .unwrap_or(false)
 }
 
 /// Registers or removes the daily check.
@@ -1026,11 +1029,10 @@ fn configure_drift_watch(enabled: bool) -> Result<(), String> {
     };
 
     let refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-    let output = std::process::Command::new("schtasks")
-        .args(&refs)
-        .creation_flags(CREATE_NO_WINDOW)
-        .output()
-        .map_err(|e| format!("could not run schtasks: {e}"))?;
+    let output = crate::system_tools::run("schtasks", |tool| {
+        tool.args(&refs).creation_flags(CREATE_NO_WINDOW).output()
+    })
+    .map_err(|e| format!("could not run schtasks: {e}"))?;
 
     if output.status.success() {
         Ok(())
@@ -1730,7 +1732,8 @@ mod tests {
         ];
 
         let total = registry.len() + composite_pro.len() + power_tuning::TWEAKS.len();
-        let pro = registry_pro + composite_pro.iter().filter(|p| **p).count()
+        let pro = registry_pro
+            + composite_pro.iter().filter(|p| **p).count()
             + power_tuning::TWEAKS.iter().filter(|t| t.pro).count();
 
         assert_eq!(total, 61, "the catalogue no longer has 61 tweaks");

--- a/src-tauri/src/netlatency.rs
+++ b/src-tauri/src/netlatency.rs
@@ -50,7 +50,7 @@ fn active_interface_guid() -> Result<String, String> {
     use std::os::windows::process::CommandExt;
     const CREATE_NO_WINDOW: u32 = 0x08000000;
 
-    let output = std::process::Command::new("powershell")
+    let output = crate::system_tools::run("powershell", |command| command
         .args([
             "-NoProfile",
             "-NonInteractive",
@@ -58,7 +58,7 @@ fn active_interface_guid() -> Result<String, String> {
             "(Get-NetAdapter | Where-Object Status -eq 'Up' | Select-Object -First 1 -ExpandProperty InterfaceGuid)",
         ])
         .creation_flags(CREATE_NO_WINDOW)
-        .output()
+        .output())
         .map_err(|e| format!("could not enumerate network adapters: {}", e))?;
 
     let guid = String::from_utf8_lossy(&output.stdout).trim().to_string();

--- a/src-tauri/src/netmaintenance.rs
+++ b/src-tauri/src/netmaintenance.rs
@@ -10,7 +10,6 @@ pub struct FlushDnsResult {
 mod imp {
     use super::FlushDnsResult;
     use std::os::windows::process::CommandExt;
-    use std::process::Command;
 
     const CREATE_NO_WINDOW: u32 = 0x08000000;
 
@@ -19,11 +18,12 @@ mod imp {
     /// nothing to roll back — it is a one-shot action, not a persistent
     /// setting, so it has no place in the rollback store.
     pub fn flush() -> Result<FlushDnsResult, String> {
-        let output = Command::new("ipconfig")
-            .arg("/flushdns")
-            .creation_flags(CREATE_NO_WINDOW)
-            .output()
-            .map_err(|e| format!("could not run ipconfig: {}", e))?;
+        let output = crate::system_tools::run("ipconfig", |tool| {
+            tool.arg("/flushdns")
+                .creation_flags(CREATE_NO_WINDOW)
+                .output()
+        })
+        .map_err(|e| format!("could not run ipconfig: {}", e))?;
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         let detail = stdout

--- a/src-tauri/src/netshaper.rs
+++ b/src-tauri/src/netshaper.rs
@@ -53,11 +53,12 @@ fn powershell(command: &str) -> Result<String, String> {
     use std::os::windows::process::CommandExt;
     const CREATE_NO_WINDOW: u32 = 0x08000000;
 
-    let output = std::process::Command::new("powershell")
-        .args(["-NoProfile", "-NonInteractive", "-Command", command])
-        .creation_flags(CREATE_NO_WINDOW)
-        .output()
-        .map_err(|e| format!("could not run PowerShell: {}", e))?;
+    let output = crate::system_tools::run("powershell", |tool| {
+        tool.args(["-NoProfile", "-NonInteractive", "-Command", command])
+            .creation_flags(CREATE_NO_WINDOW)
+            .output()
+    })
+    .map_err(|e| format!("could not run PowerShell: {}", e))?;
 
     if !output.status.success() {
         let err = String::from_utf8_lossy(&output.stderr).trim().to_string();

--- a/src-tauri/src/power.rs
+++ b/src-tauri/src/power.rs
@@ -8,11 +8,10 @@ pub fn run_powercfg(args: &[&str]) -> Result<String, String> {
     use std::os::windows::process::CommandExt;
     const CREATE_NO_WINDOW: u32 = 0x08000000;
 
-    let output = std::process::Command::new("powercfg")
-        .args(args)
-        .creation_flags(CREATE_NO_WINDOW)
-        .output()
-        .map_err(|e| format!("could not run powercfg: {}", e))?;
+    let output = crate::system_tools::run("powercfg", |tool| {
+        tool.args(args).creation_flags(CREATE_NO_WINDOW).output()
+    })
+    .map_err(|e| format!("could not run powercfg: {}", e))?;
 
     if !output.status.success() {
         return Err(format!(

--- a/src-tauri/src/restore_point.rs
+++ b/src-tauri/src/restore_point.rs
@@ -31,7 +31,9 @@ pub enum RestorePointOutcome {
 mod imp {
     use windows_sys::core::PCWSTR;
     use windows_sys::Win32::Foundation::{FreeLibrary, BOOL};
-    use windows_sys::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryW};
+    use windows_sys::Win32::System::LibraryLoader::{
+        GetProcAddress, LoadLibraryExW, LOAD_LIBRARY_SEARCH_SYSTEM32,
+    };
 
     const BEGIN_SYSTEM_CHANGE: u32 = 100;
     const APPLICATION_UNINSTALL: u32 = 1;
@@ -66,7 +68,13 @@ mod imp {
         let dll_name: Vec<u16> = "srclient.dll\0".encode_utf16().collect();
         // SAFETY: `dll_name` is a valid NUL-terminated UTF-16 string that
         // outlives the call.
-        let module = unsafe { LoadLibraryW(dll_name.as_ptr() as PCWSTR) };
+        let module = unsafe {
+            LoadLibraryExW(
+                dll_name.as_ptr() as PCWSTR,
+                std::ptr::null_mut(),
+                LOAD_LIBRARY_SEARCH_SYSTEM32,
+            )
+        };
         if module.is_null() {
             return Err("System Restore is not available on this Windows edition.".to_string());
         }
@@ -75,7 +83,7 @@ mod imp {
         // NUL-terminated ANSI string.
         let proc = unsafe { GetProcAddress(module, c"SRSetRestorePointW".as_ptr() as *const u8) };
         let Some(proc) = proc else {
-            // SAFETY: `module` came from LoadLibraryW above.
+            // SAFETY: `module` came from LoadLibraryExW above.
             unsafe { FreeLibrary(module) };
             return Err("SRSetRestorePointW was not found in srclient.dll.".to_string());
         };
@@ -106,7 +114,7 @@ mod imp {
         // SAFETY: both pointers reference live, correctly-shaped structs for
         // the duration of the call.
         let ok = unsafe { set_restore_point(&info, &mut status) };
-        // SAFETY: `module` came from LoadLibraryW above.
+        // SAFETY: `module` came from LoadLibraryExW above.
         unsafe { FreeLibrary(module) };
 
         if ok != 0 {

--- a/src-tauri/src/scheduledtasks.rs
+++ b/src-tauri/src/scheduledtasks.rs
@@ -173,7 +173,6 @@ pub(crate) fn parse_task(path: &str, xml: &str) -> Option<TaskEntry> {
 mod imp {
     use super::*;
     use std::os::windows::process::CommandExt;
-    use std::process::Command;
 
     const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
@@ -194,11 +193,10 @@ mod imp {
     /// gets the strict reading — reporting "disabled" for a call that was
     /// denied is the one failure this screen must never have.
     fn schtasks(args: &[&str], tolerate_partial: bool) -> Result<Vec<u8>, String> {
-        let output = Command::new("schtasks")
-            .args(args)
-            .creation_flags(CREATE_NO_WINDOW)
-            .output()
-            .map_err(|e| format!("could not run schtasks: {}", e))?;
+        let output = crate::system_tools::run("schtasks", |tool| {
+            tool.args(args).creation_flags(CREATE_NO_WINDOW).output()
+        })
+        .map_err(|e| format!("could not run schtasks: {}", e))?;
 
         let ok = output.status.success() || (tolerate_partial && !output.stdout.is_empty());
         if !ok {
@@ -359,7 +357,11 @@ mod tests {
     fn splits_quoted_csv_fields() {
         assert_eq!(
             split_csv_line(r#""\Adobe Acrobat Update Task","04/09/2026 10:00:00","Ready""#),
-            vec!["\\Adobe Acrobat Update Task", "04/09/2026 10:00:00", "Ready"]
+            vec![
+                "\\Adobe Acrobat Update Task",
+                "04/09/2026 10:00:00",
+                "Ready"
+            ]
         );
         // A comma inside the name must not become a field separator.
         assert_eq!(
@@ -367,7 +369,10 @@ mod tests {
             "\\Vendor, Inc. Updater"
         );
         // A doubled quote is one literal quote.
-        assert_eq!(split_csv_line(r#""He said ""hi""","x""#)[0], r#"He said "hi""#);
+        assert_eq!(
+            split_csv_line(r#""He said ""hi""","x""#)[0],
+            r#"He said "hi""#
+        );
         assert_eq!(split_csv_line("")[0], "");
     }
 
@@ -375,7 +380,9 @@ mod tests {
     /// appear on it.
     #[test]
     fn windows_own_tasks_are_never_listed() {
-        assert!(!is_third_party(r"\Microsoft\Windows\UpdateOrchestrator\Reboot"));
+        assert!(!is_third_party(
+            r"\Microsoft\Windows\UpdateOrchestrator\Reboot"
+        ));
         assert!(!is_third_party(r"Microsoft\Windows\Defrag\ScheduledDefrag"));
         // Case is not a way around it.
         assert!(!is_third_party(r"\microsoft\Windows\Foo"));
@@ -454,7 +461,10 @@ mod tests {
     fn payload_round_trips_names_containing_a_pipe() {
         let path = r"\Vendor|Updater";
         let payload = build_task_payload(path, false);
-        assert_eq!(parse_task_payload(&payload).unwrap(), (path.to_string(), false));
+        assert_eq!(
+            parse_task_payload(&payload).unwrap(),
+            (path.to_string(), false)
+        );
         assert_eq!(
             parse_task_payload(&build_task_payload(path, true)).unwrap(),
             (path.to_string(), true)

--- a/src-tauri/src/securedefrag.rs
+++ b/src-tauri/src/securedefrag.rs
@@ -191,17 +191,18 @@ where
 {
     use std::io::BufReader;
     use std::os::windows::process::CommandExt;
-    use std::process::{Command, Stdio};
+    use std::process::Stdio;
 
     const CREATE_NO_WINDOW: u32 = 0x08000000;
 
-    let mut child = Command::new("defrag")
-        .args(args)
-        .creation_flags(CREATE_NO_WINDOW)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|e| format!("could not start defrag: {}", e))?;
+    let mut child = crate::system_tools::run("defrag", |tool| {
+        tool.args(args)
+            .creation_flags(CREATE_NO_WINDOW)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+    })
+    .map_err(|e| format!("could not start defrag: {}", e))?;
 
     let stdout = child
         .stdout

--- a/src-tauri/src/services.rs
+++ b/src-tauri/src/services.rs
@@ -26,11 +26,10 @@ fn run_sc(args: &[&str]) -> Result<String, String> {
     use std::os::windows::process::CommandExt;
     const CREATE_NO_WINDOW: u32 = 0x08000000;
 
-    let output = std::process::Command::new("sc")
-        .args(args)
-        .creation_flags(CREATE_NO_WINDOW)
-        .output()
-        .map_err(|e| format!("could not run sc: {}", e))?;
+    let output = crate::system_tools::run("sc", |tool| {
+        tool.args(args).creation_flags(CREATE_NO_WINDOW).output()
+    })
+    .map_err(|e| format!("could not run sc: {}", e))?;
     let code = output.status.code();
     // Stopping an already stopped service and starting one already running
     // are idempotent successes. Other SCM failures must retain the snapshot.

--- a/src-tauri/src/startup.rs
+++ b/src-tauri/src/startup.rs
@@ -44,7 +44,7 @@ pub(crate) fn extract_exe_path(command: &str) -> Option<std::path::PathBuf> {
     let candidate = if let Some(rest) = command.strip_prefix('"') {
         // Quoted: everything up to the closing quote is the path, verbatim.
         rest.split('"').next()?.to_string()
-    } else if let Some(idx) = command.to_lowercase().find(".exe") {
+    } else if let Some(idx) = command.to_ascii_lowercase().find(".exe") {
         // Unquoted: take through the first ".exe", which handles both
         // `C:\Program Files\x\app.exe -flag` and a bare `app.exe`.
         command[..idx + 4].to_string()
@@ -572,5 +572,18 @@ mod tests {
     fn the_32_bit_run_key_is_under_wow6432node() {
         assert!(RUN32_PATH.contains("WOW6432Node"));
         assert_ne!(RUN32_PATH, RUN_PATH);
+    }
+}
+
+#[cfg(test)]
+mod unicode_path_tests {
+    #[test]
+    fn unicode_case_expansion_does_not_change_path_offsets() {
+        for path in [r"C:\İ\tool.exe", r"C:\İİ\工具.EXE"] {
+            assert_eq!(
+                super::extract_exe_path(path),
+                Some(std::path::PathBuf::from(path))
+            );
+        }
     }
 }

--- a/src-tauri/src/sysrepair.rs
+++ b/src-tauri/src/sysrepair.rs
@@ -205,7 +205,7 @@ mod imp {
     use super::*;
     use std::io::Read;
     use std::os::windows::process::CommandExt;
-    use std::process::{Command, Stdio};
+    use std::process::Stdio;
 
     const CREATE_NO_WINDOW: u32 = 0x0800_0000;
     /// How many trailing output lines each step keeps for the log view.
@@ -223,18 +223,23 @@ mod imp {
     /// Reads raw bytes rather than `BufRead::lines()` on purpose: DISM draws
     /// its progress bar by rewriting one line with `\r` and `\x08`, so a
     /// line-oriented reader shows nothing at all until the step finishes.
-    fn run_tool<F>(program: &str, args: &[&str], mut on_progress: F) -> Result<(i32, String), String>
+    fn run_tool<F>(
+        program: &str,
+        args: &[&str],
+        mut on_progress: F,
+    ) -> Result<(i32, String), String>
     where
         F: FnMut(f32),
     {
-        let mut child = Command::new(program)
-            .args(args)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .stdin(Stdio::null())
-            .creation_flags(CREATE_NO_WINDOW)
-            .spawn()
-            .map_err(|e| format!("could not start {}: {}", program, e))?;
+        let mut child = crate::system_tools::run(program, |tool| {
+            tool.args(args)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::null())
+                .stdin(Stdio::null())
+                .creation_flags(CREATE_NO_WINDOW)
+                .spawn()
+        })
+        .map_err(|e| format!("could not start {}: {}", program, e))?;
 
         let mut stdout = child
             .stdout
@@ -324,7 +329,11 @@ mod imp {
 
         for (index, (step, program, arg)) in steps.into_iter().enumerate() {
             let full: Vec<&str> = if program == "dism.exe" {
-                DISM_BASE.iter().copied().chain(std::iter::once(arg)).collect()
+                DISM_BASE
+                    .iter()
+                    .copied()
+                    .chain(std::iter::once(arg))
+                    .collect()
             } else {
                 vec![arg]
             };
@@ -440,11 +449,15 @@ mod tests {
     #[test]
     fn reads_dism_verdicts() {
         assert_eq!(
-            dism_verdict("No component store corruption detected.\nThe operation completed successfully."),
+            dism_verdict(
+                "No component store corruption detected.\nThe operation completed successfully."
+            ),
             Some(RepairStatus::Healthy)
         );
         assert_eq!(
-            dism_verdict("The component store is repairable.\nThe operation completed successfully."),
+            dism_verdict(
+                "The component store is repairable.\nThe operation completed successfully."
+            ),
             Some(RepairStatus::Repairable)
         );
         assert_eq!(
@@ -468,11 +481,17 @@ mod tests {
     #[test]
     fn sfc_only_ever_worsens_or_confirms() {
         assert_eq!(
-            sfc_downgrade("found corrupt files but was unable to fix some", RepairStatus::Healthy),
+            sfc_downgrade(
+                "found corrupt files but was unable to fix some",
+                RepairStatus::Healthy
+            ),
             RepairStatus::Unrepairable
         );
         assert_eq!(
-            sfc_downgrade("found corrupt files and successfully repaired them", RepairStatus::Healthy),
+            sfc_downgrade(
+                "found corrupt files and successfully repaired them",
+                RepairStatus::Healthy
+            ),
             RepairStatus::Repaired
         );
         // A localised summary leaves the DISM verdict exactly as it was.

--- a/src-tauri/src/system_tools.rs
+++ b/src-tauri/src/system_tools.rs
@@ -1,0 +1,146 @@
+//! Resolve native tools from Windows-owned directories, never PATH or cwd.
+use std::{io, path::PathBuf, process::Command};
+
+fn windows_directory(system: bool) -> io::Result<PathBuf> {
+    use std::os::windows::ffi::OsStringExt;
+    use windows_sys::Win32::System::SystemInformation::{
+        GetSystemDirectoryW, GetWindowsDirectoryW,
+    };
+    let mut buffer = vec![0u16; 32768];
+    // SAFETY: both APIs receive a writable buffer and its exact capacity.
+    let count = unsafe {
+        if system {
+            GetSystemDirectoryW(buffer.as_mut_ptr(), buffer.len() as u32)
+        } else {
+            GetWindowsDirectoryW(buffer.as_mut_ptr(), buffer.len() as u32)
+        }
+    } as usize;
+    if count == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if count >= buffer.len() {
+        return Err(io::Error::other("Windows directory path is too long"));
+    }
+    let path = PathBuf::from(std::ffi::OsString::from_wide(&buffer[..count]));
+    if !path.is_absolute() {
+        return Err(io::Error::other(
+            "Windows returned a relative system directory",
+        ));
+    }
+    Ok(path)
+}
+
+fn tool_path(name: &str) -> io::Result<PathBuf> {
+    let relative = match name {
+        "powershell" => r"WindowsPowerShell\v1.0\powershell.exe",
+        "cmd" => "cmd.exe",
+        "sc" => "sc.exe",
+        "schtasks" => "schtasks.exe",
+        "taskkill" => "taskkill.exe",
+        "shutdown" => "shutdown.exe",
+        "powercfg" => "powercfg.exe",
+        "ipconfig" => "ipconfig.exe",
+        "defrag" => "defrag.exe",
+        "dism" | "dism.exe" => "dism.exe",
+        "sfc" | "sfc.exe" => "sfc.exe",
+        "nvidia-smi" => "nvidia-smi.exe",
+        "explorer.exe" => return Ok(windows_directory(false)?.join("explorer.exe")),
+        _ => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Unsupported system tool",
+            ))
+        }
+    };
+    let path = windows_directory(true)?.join(relative);
+    if name == "nvidia-smi" && !path.is_file() {
+        // Older NVIDIA installers use the machine-wide Program Files tree.
+        // Read its protected registry value rather than the process environment.
+        use winreg::{enums::HKEY_LOCAL_MACHINE, RegKey};
+        let key = RegKey::predef(HKEY_LOCAL_MACHINE)
+            .open_subkey(r"SOFTWARE\Microsoft\Windows\CurrentVersion")?;
+        let base: String = key.get_value("ProgramFilesDir")?;
+        let base = PathBuf::from(base);
+        if !base.is_absolute() {
+            return Err(io::Error::other("Invalid Program Files directory"));
+        }
+        return Ok(base.join(r"NVIDIA Corporation\NVSMI\nvidia-smi.exe"));
+    }
+    Ok(path)
+}
+
+pub fn run<T>(name: &str, action: impl FnOnce(&mut Command) -> io::Result<T>) -> io::Result<T> {
+    let path = tool_path(name)?;
+    let mut command = Command::new(path);
+    use std::os::windows::process::CommandExt;
+    command.creation_flags(0x08000000);
+    let system = windows_directory(true)?;
+    let windows = windows_directory(false)?;
+    let powershell = system.join(r"WindowsPowerShell\v1.0");
+    let search_path = std::env::join_paths([
+        system.clone(),
+        windows.clone(),
+        system.join("wbem"),
+        powershell.clone(),
+    ])
+    .map_err(io::Error::other)?;
+    command
+        .env("PATH", search_path)
+        .env("SystemRoot", &windows)
+        .env("WINDIR", &windows);
+    if name == "powershell" {
+        command.env("PSModulePath", powershell.join("Modules"));
+    }
+    // Avoid loading DLLs or resolving nested tools from a user-controlled cwd.
+    command.current_dir(windows_directory(true)?);
+    if name == "cmd" {
+        command.arg("/D");
+    } // Disable Command Processor AutoRun.
+    action(&mut command)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn rejects_arbitrary_programs_and_paths() {
+        for name in [
+            "..\\cmd.exe",
+            "C:\\temp\\cmd.exe",
+            "evil",
+            "cmd.exe",
+            "powershell -Command evil",
+        ] {
+            assert!(tool_path(name).is_err());
+        }
+    }
+    #[test]
+    fn uses_absolute_windows_paths() {
+        for name in ["cmd", "powershell", "sc", "sfc", "dism", "explorer.exe"] {
+            let path = tool_path(name).unwrap();
+            assert!(path.is_absolute());
+            assert!(path.is_file(), "missing {}", path.display());
+        }
+    }
+    #[test]
+    fn poisoned_child_path_does_not_replace_windows_command() {
+        let temp = std::env::temp_dir().join(format!("pct-tool-decoy-{}", std::process::id()));
+        std::fs::create_dir_all(&temp).unwrap();
+        std::fs::write(temp.join("cmd.exe"), b"not a Windows executable").unwrap();
+        let result = run("cmd", |command| {
+            assert!(std::path::Path::new(command.get_program()).is_absolute());
+            command
+                .env("PATH", &temp)
+                .args(["/C", "echo", "trusted-tool"])
+                .output()
+        });
+        std::fs::remove_file(temp.join("cmd.exe")).unwrap();
+        std::fs::remove_dir(temp).unwrap();
+        let output = result.unwrap();
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "trusted-tool"
+        );
+    }
+}

--- a/src-tauri/src/system_tools.rs
+++ b/src-tauri/src/system_tools.rs
@@ -71,8 +71,8 @@ fn tool_path(name: &str) -> io::Result<PathBuf> {
 
 pub fn run<T>(name: &str, action: impl FnOnce(&mut Command) -> io::Result<T>) -> io::Result<T> {
     let path = tool_path(name)?;
-    let mut command = Command::new(path);
     use std::os::windows::process::CommandExt;
+    let mut command = Command::new(path);
     command.creation_flags(0x08000000);
     let system = windows_directory(true)?;
     let windows = windows_directory(false)?;

--- a/src-tauri/src/systemprofile.rs
+++ b/src-tauri/src/systemprofile.rs
@@ -263,11 +263,11 @@ if ($enc -ne $null -and $enc.ChassisTypes.Count -gt 0) { $chassis = [int]$enc.Ch
 [pscustomobject]@{ media = $media; bus = $bus; chassis = $chassis } | ConvertTo-Json -Compress
 "#;
 
-    let Ok(output) = std::process::Command::new("powershell")
-        .args(["-NoProfile", "-NonInteractive", "-Command", SCRIPT])
-        .creation_flags(CREATE_NO_WINDOW)
-        .output()
-    else {
+    let Ok(output) = crate::system_tools::run("powershell", |tool| {
+        tool.args(["-NoProfile", "-NonInteractive", "-Command", SCRIPT])
+            .creation_flags(CREATE_NO_WINDOW)
+            .output()
+    }) else {
         return;
     };
 

--- a/src-tauri/src/thermals.rs
+++ b/src-tauri/src/thermals.rs
@@ -49,7 +49,6 @@ pub struct ThermalReport {
 mod imp {
     use super::{GpuReading, ThermalReport};
     use std::os::windows::process::CommandExt;
-    use std::process::Command;
 
     const CREATE_NO_WINDOW: u32 = 0x08000000;
 
@@ -66,13 +65,15 @@ mod imp {
     }
 
     fn read_nvidia() -> Vec<GpuReading> {
-        let output = Command::new("nvidia-smi")
+        let output = crate::system_tools::run("nvidia-smi", |tool| {
+            tool
             .args([
                 "--query-gpu=name,temperature.gpu,utilization.gpu,memory.used,memory.total,fan.speed,power.draw,power.limit,driver_version",
                 "--format=csv,noheader,nounits",
             ])
             .creation_flags(CREATE_NO_WINDOW)
-            .output();
+            .output()
+        });
 
         // No NVIDIA GPU means no nvidia-smi on PATH, which surfaces here as a
         // spawn error. That is an ordinary outcome, not a failure to report.
@@ -119,11 +120,12 @@ mod imp {
     fn read_cpu_temp() -> Option<f32> {
         let script = "(Get-CimInstance -Namespace root/WMI -ClassName MSAcpi_ThermalZoneTemperature -ErrorAction Stop | \
                       Select-Object -ExpandProperty CurrentTemperature) -join ','";
-        let output = Command::new("powershell")
-            .args(["-NoProfile", "-NonInteractive", "-Command", script])
-            .creation_flags(CREATE_NO_WINDOW)
-            .output()
-            .ok()?;
+        let output = crate::system_tools::run("powershell", |tool| {
+            tool.args(["-NoProfile", "-NonInteractive", "-Command", script])
+                .creation_flags(CREATE_NO_WINDOW)
+                .output()
+        })
+        .ok()?;
         if !output.status.success() {
             return None;
         }

--- a/src-tauri/src/updatewatch.rs
+++ b/src-tauri/src/updatewatch.rs
@@ -185,8 +185,11 @@ mod tests {
     use super::*;
 
     fn temp_dir(tag: &str) -> PathBuf {
-        let dir =
-            std::env::temp_dir().join(format!("pctweaker-updatewatch-{}-{}", tag, std::process::id()));
+        let dir = std::env::temp_dir().join(format!(
+            "pctweaker-updatewatch-{}-{}",
+            tag,
+            std::process::id()
+        ));
         std::fs::create_dir_all(&dir).unwrap();
         let _ = std::fs::remove_file(state_path(&dir));
         dir
@@ -204,21 +207,33 @@ mod tests {
     fn the_first_run_reports_no_update() {
         // Nothing to compare against yet. Reporting an update here would
         // greet every new install with "Windows changed your settings".
-        let now = PatchLevel { build: 26200, ubr: 9168 };
+        let now = PatchLevel {
+            build: 26200,
+            ubr: 9168,
+        };
         assert!(!patch_level_changed(None, now));
     }
 
     #[test]
     fn a_new_revision_of_the_same_build_counts() {
         // The common case: a monthly cumulative update moves UBR only.
-        let before = PatchLevel { build: 26200, ubr: 9100 };
-        let after = PatchLevel { build: 26200, ubr: 9168 };
+        let before = PatchLevel {
+            build: 26200,
+            ubr: 9100,
+        };
+        let after = PatchLevel {
+            build: 26200,
+            ubr: 9168,
+        };
         assert!(patch_level_changed(Some(before), after));
     }
 
     #[test]
     fn an_unchanged_patch_level_is_not_an_update() {
-        let same = PatchLevel { build: 26200, ubr: 9168 };
+        let same = PatchLevel {
+            build: 26200,
+            ubr: 9168,
+        };
         assert!(!patch_level_changed(Some(same), same));
     }
 
@@ -227,8 +242,14 @@ mod tests {
         // Windows uninstalling a bad update is precisely when tweaks get
         // reverted, so treating a decrease as "nothing happened" would miss
         // the case that matters most.
-        let before = PatchLevel { build: 26200, ubr: 9168 };
-        let after = PatchLevel { build: 26200, ubr: 9100 };
+        let before = PatchLevel {
+            build: 26200,
+            ubr: 9168,
+        };
+        let after = PatchLevel {
+            build: 26200,
+            ubr: 9100,
+        };
         assert!(patch_level_changed(Some(before), after));
     }
 
@@ -269,8 +290,14 @@ mod tests {
         // something else entirely.
         let states = vec![state("a", true, Some(false)), state("b", true, Some(true))];
         let report = build_report(
-            Some(PatchLevel { build: 26200, ubr: 9100 }),
-            PatchLevel { build: 26200, ubr: 9168 },
+            Some(PatchLevel {
+                build: 26200,
+                ubr: 9100,
+            }),
+            PatchLevel {
+                build: 26200,
+                ubr: 9168,
+            },
             &states,
         );
         assert!(report.windows_updated);
@@ -282,17 +309,33 @@ mod tests {
     #[test]
     fn drift_without_an_update_is_still_drift() {
         let states = vec![state("a", true, Some(false))];
-        let same = PatchLevel { build: 26200, ubr: 9168 };
+        let same = PatchLevel {
+            build: 26200,
+            ubr: 9168,
+        };
         let report = build_report(Some(same), same, &states);
         assert!(!report.windows_updated, "nothing patched the machine");
-        assert_eq!(report.reverted, vec!["a".to_string()], "but the tweak is still off");
+        assert_eq!(
+            report.reverted,
+            vec!["a".to_string()],
+            "but the tweak is still off"
+        );
     }
 
     #[test]
     fn the_state_survives_a_round_trip() {
         let dir = temp_dir("roundtrip");
-        let level = PatchLevel { build: 26200, ubr: 9168 };
-        write_state(&dir, &WatchState { last_seen: Some(level) }).unwrap();
+        let level = PatchLevel {
+            build: 26200,
+            ubr: 9168,
+        };
+        write_state(
+            &dir,
+            &WatchState {
+                last_seen: Some(level),
+            },
+        )
+        .unwrap();
         assert_eq!(read_state(&dir).last_seen, Some(level));
         std::fs::remove_dir_all(&dir).ok();
     }
@@ -395,11 +438,12 @@ $xml.LoadXml(@'
 "#
     );
 
-    let output = std::process::Command::new("powershell")
-        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
-        .creation_flags(CREATE_NO_WINDOW)
-        .output()
-        .map_err(|e| format!("could not run PowerShell: {e}"))?;
+    let output = crate::system_tools::run("powershell", |tool| {
+        tool.args(["-NoProfile", "-NonInteractive", "-Command", &script])
+            .creation_flags(CREATE_NO_WINDOW)
+            .output()
+    })
+    .map_err(|e| format!("could not run PowerShell: {e}"))?;
 
     if output.status.success() {
         Ok(())

--- a/src-tauri/src/x3d.rs
+++ b/src-tauri/src/x3d.rs
@@ -145,8 +145,8 @@ mod win {
     }
 
     fn cpu_name() -> String {
-        std::process::Command::new("powershell")
-            .args([
+        crate::system_tools::run("powershell", |tool| {
+            tool.args([
                 "-NoProfile",
                 "-NonInteractive",
                 "-Command",
@@ -154,10 +154,11 @@ mod win {
             ])
             .creation_flags(CREATE_NO_WINDOW)
             .output()
-            .ok()
-            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-            .filter(|s| !s.is_empty())
-            .unwrap_or_else(|| "Unknown processor".to_string())
+        })
+        .ok()
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "Unknown processor".to_string())
     }
 
     pub fn report() -> X3dReport {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "pc-tweaker-app",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "identifier": "com.aurel.pc-tweaker-app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tests/console_windows.rs
+++ b/src-tauri/tests/console_windows.rs
@@ -70,7 +70,9 @@ fn every_spawned_process_is_told_not_to_open_a_console() {
         let lines: Vec<&str> = source.lines().collect();
 
         for (index, line) in lines.iter().enumerate() {
-            if !line.contains("Command::new") || line.contains(EXEMPT) {
+            if (!line.contains("Command::new") && !line.contains("crate::system_tools::run("))
+                || line.contains(EXEMPT)
+            {
                 continue;
             }
             sites += 1;
@@ -92,11 +94,7 @@ fn every_spawned_process_is_told_not_to_open_a_console() {
                     .unwrap_or(file)
                     .to_string_lossy()
                     .replace('\\', "/");
-                unguarded.push(format!(
-                    "src/{name}:{}  {}",
-                    index + 1,
-                    line.trim()
-                ));
+                unguarded.push(format!("src/{name}:{}  {}", index + 1, line.trim()));
             }
         }
     }

--- a/src-tauri/tests/console_windows.rs
+++ b/src-tauri/tests/console_windows.rs
@@ -80,10 +80,12 @@ fn every_spawned_process_is_told_not_to_open_a_console() {
             // The whole builder chain, which is where the flag goes — not
             // just the line that names the program.
             let mut statement = String::new();
-            for next in lines.iter().skip(index).take(MAX_STATEMENT_LINES) {
+            for (offset, next) in lines.iter().skip(index).take(MAX_STATEMENT_LINES).enumerate() {
                 statement.push_str(next);
                 statement.push('\n');
-                if next.trim_end().ends_with(';') {
+                // The shared helper sets creation_flags in the next statement
+                // after binding its Command. Chained builders end normally.
+                if next.trim_end().ends_with(';') && !(offset == 0 && next.contains("let mut command = Command::new")) {
                     break;
                 }
             }


### PR DESCRIPTION
# PC Tweaker 1.10.1

Security and reliability update for Windows system tools, startup entries and driver update reporting.

- Native tools now use explicit Windows-owned paths instead of executable search paths. Child tool search paths and PowerShell module paths are restricted, and Command Processor AutoRun is disabled for the Windows Update launcher.
- System Restore loads its library from the Windows system directory only.
- Fixed startup-entry parsing for Unicode paths that could previously panic or be classified incorrectly.
- Driver update results now count every requested update that did not install, including download failures, and reject malformed results rather than reporting zero failures.

The original interface, editable profiles, pricing and existing subscription/Lifetime entitlements are unchanged. Official Windows installers are digitally signed by Aurelio Avila. Code signing does not guarantee that every SmartScreen warning disappears.
