### PR TITLE
Polish support emails and complete purchase receipt text

### DIFF
--- a/backend/src/emails/pro-welcome.ts
+++ b/backend/src/emails/pro-welcome.ts
@@ -107,6 +107,21 @@ export function proWelcomeSubject(product?: string | null): string {
     : "You're Pro now — welcome to PC Tweaker Pro";
 }
 
+export function proWelcomeText({ product, firstName, email, plan, priceLabel, renewsOn }: ProWelcomeEmailInput): string {
+  const brand = brandFor(product);
+  const planLabel = plan === "lifetime" ? "Pro — Lifetime" : plan === "annual" ? "Pro — Annual" : "Pro — Monthly";
+  return [
+    `${brand.headline}, ${firstName || "there"}.`, "",
+    renewsOn ? brand.intro : brand.introOneOff, "",
+    "What you've unlocked:", ...brand.highlights.map(line => `- ${line.replace(/&amp;/g, "&")}`), "",
+    `Plan: ${planLabel}`, `Price: ${priceLabel}`,
+    renewsOn ? `Renews on: ${renewsOn}` : "Access: Never expires", "",
+    `${brand.ctaLabel}: ${brand.siteUrl}`, brand.signInHint.replace("{email}", email), "",
+    renewsOn ? "Cancel anytime from your account settings." : "This purchase does not renew.",
+    "Questions? Just reply to this email.",
+  ].join("\n");
+}
+
 export function proWelcomeHtml({ product, firstName, email, plan, priceLabel, renewsOn }: ProWelcomeEmailInput): string {
   const brand = brandFor(product);
   const name = escapeHtml(firstName || "there");

--- a/backend/src/routes/stripe.ts
+++ b/backend/src/routes/stripe.ts
@@ -14,7 +14,7 @@ import {
   tipSessionParams,
 } from "../stripe-policy";
 import { sendMail } from "../mailer";
-import { brandFor, proWelcomeHtml, proWelcomeSubject } from "../emails/pro-welcome";
+import { brandFor, proWelcomeHtml, proWelcomeSubject, proWelcomeText } from "../emails/pro-welcome";
 import { SUPPORT_INBOX } from "../support-inbox";
 import { lifetimeOffer, lifetimeCheckoutDecision } from "../lifetime-offer";
 import { queueReceipt, type Receipt } from "../receipt-outbox";
@@ -558,6 +558,15 @@ export async function deliverProReceipt(receipt: Receipt): Promise<void> {
     const result = await sendMail({
       to: user.email,
       subject: proWelcomeSubject(product),
+      replyTo: SUPPORT_INBOX,
+      text: proWelcomeText({
+        product,
+        firstName: user.first_name || "there",
+        email: user.email,
+        plan: plan || "monthly",
+        priceLabel: chargedLabel ?? PLAN_PRICE_LABELS[plan || "monthly"] ?? PLAN_PRICE_LABELS.monthly,
+        renewsOn,
+      }),
       html: proWelcomeHtml({
         product,
         firstName: user.first_name || "there",

--- a/backend/src/routes/support.ts
+++ b/backend/src/routes/support.ts
@@ -4,6 +4,7 @@ import { isValidEmail } from "../auth";
 import { sendMail, isConfigured as mailIsConfigured, MailError } from "../mailer";
 import { SUPPORT_INBOX } from "../support-inbox";
 import { consumeGlobalBudget, singleLine } from "../public-form-guard";
+import { emailShell } from "../emails/layout";
 
 const router = express.Router();
 
@@ -154,6 +155,7 @@ router.post("/", supportLimiter, async (req: Request, res: Response) => {
       to: SUPPORT_INBOX,
       subject: singleLine(`[PC Tweaker support] ${subject}`),
       html,
+      text: `New PC Tweaker support request\n\nName: ${name}\nEmail: ${email}\nCategory: ${CATEGORY_LABELS[category]}\nSubject: ${subject}\nSystem: ${systemInfo || "Not provided"}\n\n${message}`,
       replyTo: email,
     });
   } catch (err) {
@@ -177,10 +179,15 @@ router.post("/", supportLimiter, async (req: Request, res: Response) => {
   void sendMail({
     to: email,
     subject: "We received your PC Tweaker support request",
-    html: `<p>Hi ${escapeHtml(name)},</p>
-           <p>Thanks for getting in touch. Your message about "<strong>${escapeHtml(subject)}</strong>" has reached our support team and we'll reply to this address, usually within one business day.</p>
-           <p>If you didn't send this, you can ignore this email — nothing else will follow.</p>
-           <p>— The PC Tweaker team</p>`,
+    replyTo: SUPPORT_INBOX,
+    html: emailShell({
+      eyebrow: "Support request received",
+      headline: "We're on it.",
+      intro: `Hi ${name}, your message has reached the PC Tweaker support team. We'll reply to this email address.`,
+      note: "If you did not contact us, you can ignore this message.",
+      footerNote: "Need to add a detail? Reply to this email. Never send your password or payment card details.",
+    }),
+    text: `Hi ${name},\n\nYour message has reached the PC Tweaker support team. We'll reply to this email address.\n\nNeed to add a detail? Reply to this email. Never send your password or payment card details.\n\nIf you did not contact us, you can ignore this message.\n\nPC Tweaker`,
   }).catch((err: Error) => console.error("support acknowledgement failed:", err.message));
 
   res.status(200).json({ ok: true });

--- a/backend/test/purchase-text.test.mjs
+++ b/backend/test/purchase-text.test.mjs
@@ -10,7 +10,7 @@ test('purchase text includes actual price, renewal and product destination', () 
 
 test('lifetime purchase text does not promise a renewal', () => {
   const text = proWelcomeText({product:'uninstaller',firstName:'',email:'test@example.com',plan:'lifetime',priceLabel:'EUR 30.00',renewsOn:null});
-  assert.ok(text.includes('https://pctweaker.app/uninstaller'));
+  assert.equal(text.split('\n').find(line => line.startsWith('Open Uninstaller:')), 'Open Uninstaller: https://pctweaker.app/uninstaller');
   assert.ok(text.includes('This purchase does not renew.'));
   assert.ok(!text.includes('Renews on:'));
 });

--- a/backend/test/purchase-text.test.mjs
+++ b/backend/test/purchase-text.test.mjs
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { proWelcomeText } from '../dist/emails/pro-welcome.js';
+
+test('purchase text includes actual price, renewal and product destination', () => {
+  const text = proWelcomeText({product:'pctweaker',firstName:'Aurelio',email:'test@example.com',plan:'annual',priceLabel:'EUR 24.00',renewsOn:'September 7, 2027'});
+  for (const value of ['Aurelio','EUR 24.00','September 7, 2027','https://pctweaker.app','test@example.com']) assert.ok(text.includes(value));
+  assert.ok(!text.includes('&amp;'));
+});
+
+test('lifetime purchase text does not promise a renewal', () => {
+  const text = proWelcomeText({product:'uninstaller',firstName:'',email:'test@example.com',plan:'lifetime',priceLabel:'EUR 30.00',renewsOn:null});
+  assert.ok(text.includes('https://pctweaker.app/uninstaller'));
+  assert.ok(text.includes('This purchase does not renew.'));
+  assert.ok(!text.includes('Renews on:'));
+});


### PR DESCRIPTION
Use the shared branded shell for support acknowledgements, omit untrusted subject echoes, include plain-text support and purchase messages, and route replies to the support inbox. Validation: backend build and 106 tests pass.