### PR TITLE
Improve transactional email readability

### DIFF
--- a/backend/src/emails/layout.ts
+++ b/backend/src/emails/layout.ts
@@ -48,6 +48,8 @@ export function escapeHtml(value: string): string {
 }
 
 const DEFAULT_ACCENT = "#ff5500";
+// Secondary text remains readable on the dark email surface (WCAG AA).
+export const EMAIL_MUTED_TEXT = "#9ca3af";
 const DEFAULT_PRODUCT = "PC Tweaker";
 const DEFAULT_SITE = "https://pctweaker.app";
 const DEFAULT_LOGO = "https://pctweaker.app/logo.png";
@@ -64,7 +66,7 @@ export function bulletRow(accent: string, text: string): string {
 /** A two-column key/value row, for the receipt block. */
 export function detailRow(label: string, value: string): string {
   return `              <tr>
-                <td style="font-size:13px; color:#5b5f66; padding:4px 0;">${escapeHtml(label)}</td>
+                <td style="font-size:13px; color:${EMAIL_MUTED_TEXT}; padding:4px 0;">${escapeHtml(label)}</td>
                 <td style="font-size:13px; color:#e5e7eb; padding:4px 0; text-align:right;">${escapeHtml(value)}</td>
               </tr>`;
 }
@@ -97,7 +99,7 @@ export function emailShell({
     ? `
         <tr>
           <td style="padding:8px 40px 0; text-align:center;">
-            <p style="margin:0; font-size:13px; color:#5b5f66;">${escapeHtml(note)}</p>
+            <p style="margin:0; font-size:13px; color:${EMAIL_MUTED_TEXT}; line-height:1.6;">${escapeHtml(note)}</p>
           </td>
         </tr>`
     : "";
@@ -135,9 +137,9 @@ export function emailShell({
 ${bodyHtml}${button}${noteRow}${afterActionHtml}
         <tr>
           <td style="padding:32px 40px 40px; text-align:center;">
-            <p style="margin:0; font-size:13px; color:#5b5f66; line-height:1.6;">
+            <p style="margin:0; font-size:13px; color:${EMAIL_MUTED_TEXT}; line-height:1.6;">
               ${footerNote ? `${escapeHtml(footerNote)}<br>` : ""}
-              ${escapeHtml(productName)} &middot; <a href="${escapeHtml(siteUrl)}" style="color:#5b5f66;">pctweaker.app</a>
+              ${escapeHtml(productName)} &middot; <a href="${escapeHtml(siteUrl)}" style="color:${EMAIL_MUTED_TEXT};">pctweaker.app</a>
             </p>
           </td>
         </tr>

--- a/backend/src/emails/pro-welcome.ts
+++ b/backend/src/emails/pro-welcome.ts
@@ -10,7 +10,7 @@
  */
 
 /** The per-product words and colours the shared layout is filled with. */
-import { bulletRow, detailRow, emailShell } from "./layout";
+import { bulletRow, detailRow, emailShell, EMAIL_MUTED_TEXT } from "./layout";
 
 export type ProductBrand = {
   /** Shown in the subject line and the footer, e.g. "PC Tweaker Pro". */
@@ -137,7 +137,7 @@ export function proWelcomeHtml({ product, firstName, email, plan, priceLabel, re
 
         <tr>
           <td style="padding:28px 40px 0;">
-            <div style="font-size:13px; font-weight:700; letter-spacing:0.1em; text-transform:uppercase; color:#5b5f66; margin-bottom:16px;">What you've unlocked</div>
+            <div style="font-size:13px; font-weight:700; letter-spacing:0.1em; text-transform:uppercase; color:${EMAIL_MUTED_TEXT}; margin-bottom:16px;">What you've unlocked</div>
             <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
 ${brand.highlights.map((h) => bulletRow(brand.accent, h)).join("\n")}
             </table>

--- a/backend/test/email-contrast.test.mjs
+++ b/backend/test/email-contrast.test.mjs
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EMAIL_MUTED_TEXT, emailShell, detailRow } from '../dist/emails/layout.js';
+import { proWelcomeHtml } from '../dist/emails/pro-welcome.js';
+
+function luminance(hex) {
+  const channels = hex.slice(1).match(/../g).map(value => parseInt(value, 16) / 255)
+    .map(value => value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4);
+  return channels[0] * 0.2126 + channels[1] * 0.7152 + channels[2] * 0.0722;
+}
+
+test('secondary email text meets AA contrast on both dark surfaces', () => {
+  for (const background of ['#050506', '#0a0a0c']) {
+    assert.ok((luminance(EMAIL_MUTED_TEXT) + 0.05) / (luminance(background) + 0.05) >= 4.5);
+  }
+});
+
+test('account notes, receipt labels and purchase headings use readable text', () => {
+  const shell = emailShell({ eyebrow: 'Account', headline: 'Check your email', intro: 'Continue securely.', note: 'This link expires.', footerNote: 'Contact support.' });
+  const receipt = proWelcomeHtml({ firstName: 'Aurelio', email: 'test@example.com', plan: 'annual', priceLabel: 'EUR 24.00', renewsOn: 'September 7, 2027' });
+  for (const html of [shell, receipt, detailRow('Plan', 'Annual')]) {
+    assert.ok(html.includes(`color:${EMAIL_MUTED_TEXT}`));
+    assert.ok(!html.includes('#5b5f66'));
+  }
+});


### PR DESCRIPTION
Improve secondary text contrast in account, support and purchase emails while preserving dark/orange branding. Add regression tests for AA contrast and rendered templates. All 108 backend tests pass. No installer, release tag, authentication link or payment behavior is changed.