### PR TITLE
Verify Windows signatures before distributing release artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,58 +34,9 @@ jobs:
       - name: Run checks
         run: npm run check
 
-      # Signing deliberately does NOT happen here.
-      #
-      # The updater private key signs auto-updates for every existing
-      # install, so storing it in this public repo's secrets would mean any
-      # compromise of the repo, a workflow, or a third-party action could
-      # push a signed malicious update to every user. It stays on the
-      # release machine; CI's job is to prove the tag compiles and bundles.
-      #
-      # The "never ship an unsigned release" guard that used to live here now
-      # lives where releases are actually produced: scripts/make-latest-json.mjs
-      # refuses to write latest.json when the .sig is missing, so an unsigned
-      # build cannot reach the updater endpoint.
-      #
-      # The env vars are conditionally exported rather than always set: an
-      # EMPTY TAURI_SIGNING_PRIVATE_KEY is not the same as an unset one -
-      # tauri tries to decode the empty string and dies with "Missing comment
-      # in secret key", which is exactly how this workflow failed on every
-      # tag from v0.4.3 to v1.2.0.
-      - name: Build Tauri app (verification build, unsigned)
+      # CI proves the source builds; it does not distribute unsigned installers.
+      # Publisher and updater signing happen on the authorized release machine.
+      # The local manifest helper, stable aliases and WinGet have independent gates.
+      - name: Build without distributing verification artifacts
         shell: bash
-        env:
-          SIGNING_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          SIGNING_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        run: |
-          if [ -n "$SIGNING_KEY" ]; then
-            echo "Signing key present - producing signed bundles."
-            export TAURI_SIGNING_PRIVATE_KEY="$SIGNING_KEY"
-            export TAURI_SIGNING_PRIVATE_KEY_PASSWORD="$SIGNING_KEY_PASSWORD"
-            npm run tauri build
-          else
-            # `createUpdaterArtifacts` is true in tauri.conf.json, and with a
-            # public key configured but no private key this version of the
-            # Tauri CLI exits 1 *after* writing both bundles. Turning the
-            # updater artifact off for this run is what makes an unsigned
-            # verification build possible at all - it changes nothing about
-            # the released installers, which are built and signed locally.
-            echo "No signing key in CI (by design) - unsigned verification build."
-            npm run tauri build -- --config '{"bundle":{"createUpdaterArtifacts":false}}'
-          fi
-
-      - name: Upload installer artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: pc-tweaker-installers-unsigned
-          # .sig files are globbed too so that a run WITH a key (a future
-          # self-hosted or manually dispatched signed build) uploads a
-          # complete, updater-usable set. Without a key they simply do not
-          # exist, and these artifacts are for inspection only - the shipped
-          # installers are the locally signed ones attached to the release.
-          if-no-files-found: warn
-          path: |
-            src-tauri/target/release/bundle/nsis/*.exe
-            src-tauri/target/release/bundle/nsis/*.exe.sig
-            src-tauri/target/release/bundle/msi/*.msi
-            src-tauri/target/release/bundle/msi/*.msi.sig
+        run: npm run tauri build -- --config '{"bundle":{"createUpdaterArtifacts":false}}'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -47,6 +47,9 @@ jobs:
       - name: TypeScript
         run: npx tsc --noEmit
 
+      - name: Release verification regression tests
+        run: node --test scripts/release-verification.test.mjs
+
       - name: Translations (keys + placeholders across all languages)
         run: npm run check:i18n
 

--- a/.github/workflows/stable-download-alias.yml
+++ b/.github/workflows/stable-download-alias.yml
@@ -21,8 +21,14 @@ permissions:
 
 jobs:
   alias:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
     steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+        with:
+          persist-credentials: false
       # Event/input values are passed through `env:` rather than interpolated
       # into the script text: a `${{ }}` inside `run:` is pasted verbatim
       # before the shell parses it, so a crafted tag name would execute as
@@ -38,6 +44,7 @@ jobs:
           TAG="$RELEASE_TAG"
           if [ -z "$TAG" ]; then TAG="$INPUT_TAG"; fi
           if [ -z "$TAG" ]; then TAG=$(gh release view --json tagName --jq .tagName); fi
+          [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit 1
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Download versioned installers
@@ -51,11 +58,22 @@ jobs:
             --pattern "*_x64_en-US.msi" \
             --clobber -D dl
 
+      - name: Verify publisher and timestamps before creating aliases
+        shell: pwsh
+        run: |
+          $files = @(Get-ChildItem -LiteralPath dl -File)
+          if ($files.Count -ne 2) { throw 'Expected exactly one EXE and one MSI.' }
+          ./scripts/verify-authenticode.ps1 -Path $files.FullName
+
       - name: Rename to stable filenames
         run: |
           mkdir -p out
           cp "$(ls dl/*_x64-setup.exe)" out/PCTweaker-Setup.exe
           cp "$(ls dl/*_x64_en-US.msi)" out/PCTweaker-Setup.msi
+
+      - name: Verify final aliases before upload
+        shell: pwsh
+        run: ./scripts/verify-authenticode.ps1 -Path @('out/PCTweaker-Setup.exe', 'out/PCTweaker-Setup.msi')
 
       - name: Upload stable aliases to the release
         env:

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -26,7 +26,24 @@ permissions:
   contents: read
 
 jobs:
+  verify:
+    runs-on: windows-latest
+    outputs:
+      tag: ${{ steps.verify.outputs.tag }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+        with:
+          persist-credentials: false
+      - name: Verify release installers before catalog submission
+        id: verify
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag || github.event.release.tag_name }}
+        run: ./scripts/verify-published-release.ps1 -Tag $env:RELEASE_TAG
+
   publish:
+    needs: verify
     runs-on: ubuntu-latest
     steps:
       # Same shape as the Discord announcement workflow: a missing secret
@@ -35,8 +52,10 @@ jobs:
       # something that can be generated from inside a workflow.
       - name: Check for the winget PAT
         id: gate
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
         run: |
-          if [ -z "${{ secrets.WINGET_TOKEN }}" ]; then
+          if [ -z "$WINGET_TOKEN" ]; then
             echo "::warning::WINGET_TOKEN secret is not set; skipping the winget submission"
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
@@ -58,5 +77,5 @@ jobs:
           # fails the job before Komac ever runs. The event carries the tag
           # already, so fall back to it and keep the manual input as an
           # override for re-submitting an older release.
-          release-tag: ${{ inputs.tag || github.event.release.tag_name }}
+          release-tag: ${{ needs.verify.outputs.tag }}
           token: ${{ secrets.WINGET_TOKEN }}

--- a/RELEASE-VERIFICATION.md
+++ b/RELEASE-VERIFICATION.md
@@ -1,0 +1,26 @@
+# Windows release verification
+
+CI compilation is a verification step, not a download channel: unsigned build
+artifacts are not uploaded. Build and sign releases on the authorized release
+workstation using the existing publisher certificate and updater key.
+
+Before preparing `latest.json`, `scripts/make-latest-json.mjs` requires the
+application, EXE installer and MSI installer to pass Windows Authenticode,
+publisher identity (**Aurelio Avila**) and trusted timestamp verification.
+Both installers must also have valid Tauri updater signatures for the public
+key installed in the application. The helper rejects changed bytes.
+
+PowerShell 7, Windows SDK SignTool and minisign must be available locally.
+`SIGNTOOL_PATH` and `MINISIGN_PATH` may identify installed verification tools;
+they are paths, not signing credentials. Missing tools stop preparation.
+
+The stable-download workflow verifies the downloaded installers and final
+aliases before uploading. WinGet submission first verifies published installers
+against GitHub API SHA-256 digests and Windows trust, and uses the checked tag.
+These checks do not sign files, rotate keys or require a new certificate.
+
+Do not change verified assets after publication. A new build needs a new
+release and fresh signatures. Manual uploads outside these helpers still
+require independent verification of the final installers and packaged payloads.
+Code signing identifies a publisher; it does not guarantee an absence of
+SmartScreen warnings or application vulnerabilities.

--- a/RELEASE-VERIFICATION.md
+++ b/RELEASE-VERIFICATION.md
@@ -5,7 +5,7 @@ artifacts are not uploaded. Build and sign releases on the authorized release
 workstation using the existing publisher certificate and updater key.
 
 Before preparing `latest.json`, `scripts/make-latest-json.mjs` requires the
-application, EXE installer and MSI installer to pass Windows Authenticode,
+application, DLLs in its release directory, EXE installer and MSI installer to pass Windows Authenticode,
 publisher identity (**Aurelio Avila**) and trusted timestamp verification.
 Both installers must also have valid Tauri updater signatures for the public
 key installed in the application. The helper rejects changed bytes.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing PC Tweaker
 
-Official releases are built locally and published by Aurelio Avila. CI verification artifacts are unsigned and must not be distributed as official releases.
+Official releases are built locally and published by Aurelio Avila. CI verification builds are unsigned and their installers are not uploaded. See the [automated release verification gates](RELEASE-VERIFICATION.md) for required local tools and checks.
 
 1. Save a source checkpoint. Update package.json, its lockfile, src-tauri/Cargo.toml, its lockfile and src-tauri/tauri.conf.json to the same new version. Update catalog counts, translated copy and release notes when behavior changes.
 2. Run TypeScript, translation coverage and quality, lint, formatting, frontend tests, backend tests and the site build. Run the complete Rust suite on the disposable Windows CI runner. Run the explicitly ignored native power test there as well: it creates and deletes an inactive plan and verifies AC restoration, unchanged DC policy and unchanged active plan.

--- a/scripts/make-latest-json.mjs
+++ b/scripts/make-latest-json.mjs
@@ -6,12 +6,15 @@
  *
  * Reads the version from src-tauri/tauri.conf.json, the signature from the
  * .exe.sig next to the setup bundle, and the release notes from the given
- * file (first paragraph). Refuses to run if the .sig is missing — an
- * unsigned manifest would strand every existing install on the old version.
+ * file (first paragraph). Requires valid publisher signatures, timestamps
+ * and cryptographically verified updater signatures before writing output.
  */
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { verifyUpdater } from "./verify-updater.mjs";
 
 const root = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
 const conf = JSON.parse(fs.readFileSync(path.join(root, "src-tauri", "tauri.conf.json"), "utf8"));
@@ -23,7 +26,9 @@ if (!repoUrl) {
 }
 
 const nsisDir = path.join(root, "src-tauri", "target", "release", "bundle", "nsis");
-const setup = fs.readdirSync(nsisDir).find((f) => f.includes(`_${version}_`) && f.endsWith("-setup.exe"));
+const setups = fs.readdirSync(nsisDir).filter((f) => f.includes(`_${version}_`) && f.endsWith("_x64-setup.exe"));
+if (setups.length !== 1) throw new Error("Expected exactly one current x64 setup.");
+const setup = setups[0];
 if (!setup) {
   console.error(`No v${version} -setup.exe found in ${nsisDir}. Run the signed build first.`);
   process.exit(1);
@@ -60,13 +65,34 @@ if (/[^A-Za-z0-9.\-_]/.test(assetName)) {
   process.exit(1);
 }
 
+const msiDir = path.join(root, "src-tauri", "target", "release", "bundle", "msi");
+const msis = fs.readdirSync(msiDir).filter((file) => file.includes(`_${version}_`) && file.endsWith(".msi"));
+if (msis.length !== 1) throw new Error("Expected exactly one current MSI installer.");
+const releaseDir = path.join(root, "src-tauri", "target", "release");
+const binaries = [
+  path.join(releaseDir, "pc-tweaker-app.exe"),
+  path.join(nsisDir, setup),
+  path.join(msiDir, msis[0]),
+];
+const sha256 = (file) => createHash("sha256").update(fs.readFileSync(file)).digest("hex");
+const hashes = new Map(binaries.map((file) => [file, sha256(file)]));
+for (const binary of binaries) {
+  execFileSync("pwsh", ["-NoProfile", "-NonInteractive", "-File",
+    path.join(root, "scripts", "verify-authenticode.ps1"), "-Path", binary], { stdio: "inherit" });
+}
+const updaterSignature = verifyUpdater(path.join(nsisDir, setup), conf.plugins.updater.pubkey);
+verifyUpdater(path.join(msiDir, msis[0]), conf.plugins.updater.pubkey);
+for (const [file, hash] of hashes) {
+  if (sha256(file) !== hash) throw new Error(`File changed during verification: ${file}`);
+}
+
 const manifest = {
   version,
   notes,
   pub_date: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
   platforms: {
     "windows-x86_64": {
-      signature: fs.readFileSync(sigPath, "utf8").trim(),
+      signature: updaterSignature,
       url: `${repoUrl}/releases/download/v${version}/${assetName}`,
     },
   },

--- a/scripts/make-latest-json.mjs
+++ b/scripts/make-latest-json.mjs
@@ -71,6 +71,7 @@ if (msis.length !== 1) throw new Error("Expected exactly one current MSI install
 const releaseDir = path.join(root, "src-tauri", "target", "release");
 const binaries = [
   path.join(releaseDir, "pc-tweaker-app.exe"),
+  ...fs.readdirSync(releaseDir).filter((file) => file.endsWith(".dll")).map((file) => path.join(releaseDir, file)),
   path.join(nsisDir, setup),
   path.join(msiDir, msis[0]),
 ];

--- a/scripts/release-safety.ps1
+++ b/scripts/release-safety.ps1
@@ -1,0 +1,26 @@
+function Assert-ReleaseTag {
+    param([AllowNull()][AllowEmptyString()][string]$Tag)
+    # Stable releases only. Absolute anchors also reject a trailing newline.
+    if ($Tag -cnotmatch '\Av(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\z') {
+        throw 'Invalid release tag: expected vMAJOR.MINOR.PATCH with no whitespace or newlines.'
+    }
+}
+
+function Assert-TemporaryDirectory {
+    param([string]$ResolvedDirectory, [string]$ExpectedDirectory, [string]$TempRoot)
+    $comparison = [StringComparison]::OrdinalIgnoreCase
+    $root = [IO.Path]::GetFullPath($TempRoot).TrimEnd('\', '/')
+    $candidate = [IO.Path]::GetFullPath($ResolvedDirectory).TrimEnd('\', '/')
+    $expected = [IO.Path]::GetFullPath($ExpectedDirectory).TrimEnd('\', '/')
+    if (-not [IO.Path]::IsPathFullyQualified($ResolvedDirectory) -or
+        -not $candidate.Equals($expected, $comparison) -or
+        -not $candidate.StartsWith($root + [IO.Path]::DirectorySeparatorChar, $comparison) -or
+        -not ([IO.Path]::GetDirectoryName($candidate)).Equals($root, $comparison) -or
+        [IO.Path]::GetFileName($candidate) -cnotmatch '\Apctweaker-release-[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}\z') {
+        throw 'Unsafe temporary cleanup target: expected the exact absolute directory created under the temporary root.'
+    }
+    $item = Get-Item -LiteralPath $candidate -Force
+    if (-not $item.PSIsContainer -or ($item.Attributes -band [IO.FileAttributes]::ReparsePoint)) {
+        throw 'Unsafe temporary cleanup target: directory links and non-directories are not allowed.'
+    }
+}

--- a/scripts/release-verification.test.mjs
+++ b/scripts/release-verification.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { verifyUpdater, removeVerificationDirectory } from "./verify-updater.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const conf = JSON.parse(fs.readFileSync(path.join(root, "src-tauri/tauri.conf.json")));
+
+test("updater cleanup rejects the temporary root and unrelated directories", () => {
+  const temporaryRoot = fs.realpathSync(os.tmpdir());
+  assert.throws(() => removeVerificationDirectory(temporaryRoot, temporaryRoot), /Unsafe/);
+  assert.throws(() => removeVerificationDirectory(root, temporaryRoot), /Unsafe/);
+  const directory = fs.mkdtempSync(path.join(temporaryRoot, "pctweaker-verify-"));
+  assert.throws(() => removeVerificationDirectory(directory, root), /Unsafe/);
+  assert.ok(fs.existsSync(directory));
+  removeVerificationDirectory(directory, temporaryRoot);
+  assert.equal(fs.existsSync(directory), false);
+});
+
+test("missing and empty updater signatures fail closed", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pctweaker-verify-"));
+  try {
+    const file = path.join(dir, "setup.exe");
+    fs.writeFileSync(file, "unsigned fixture");
+    assert.throws(() => verifyUpdater(file, conf.plugins.updater.pubkey), /ENOENT/);
+    fs.writeFileSync(file + ".sig", "");
+    assert.throws(() => verifyUpdater(file, conf.plugins.updater.pubkey), /malformed/);
+  } finally {
+    removeVerificationDirectory(dir, fs.realpathSync(os.tmpdir()));
+  }
+});
+
+test(
+  "unsigned bundles do not produce a manifest or stable alias",
+  { skip: process.platform !== "win32" },
+  () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pctweaker-verify-"));
+    try {
+      fs.cpSync(path.join(root, "scripts"), path.join(dir, "scripts"), { recursive: true });
+      const release = path.join(dir, "src-tauri/target/release");
+      const nsis = path.join(release, "bundle/nsis");
+      const msi = path.join(release, "bundle/msi");
+      fs.mkdirSync(nsis, { recursive: true });
+      fs.mkdirSync(msi, { recursive: true });
+      fs.writeFileSync(path.join(dir, "src-tauri/tauri.conf.json"), JSON.stringify(conf));
+      fs.writeFileSync(path.join(dir, "notes.md"), "Verification fixture.");
+      fs.writeFileSync(path.join(release, "pc-tweaker-app.exe"), "unsigned");
+      fs.writeFileSync(path.join(nsis, `Test_${conf.version}_x64-setup.exe`), "unsigned");
+      fs.writeFileSync(
+        path.join(nsis, `Test_${conf.version}_x64-setup.exe.sig`),
+        "present but invalid",
+      );
+      fs.writeFileSync(path.join(msi, `Test_${conf.version}_x64_en-US.msi`), "unsigned");
+      const result = spawnSync(
+        process.execPath,
+        [path.join(dir, "scripts/make-latest-json.mjs"), path.join(dir, "notes.md")],
+        { encoding: "utf8" },
+      );
+      assert.notEqual(result.status, 0);
+      assert.match(result.stdout + result.stderr, /Authenticode verification failed/);
+      assert.equal(fs.existsSync(path.join(nsis, "latest.json")), false);
+      assert.equal(fs.existsSync(path.join(nsis, "PCTweaker-Setup.exe")), false);
+    } finally {
+      removeVerificationDirectory(dir, fs.realpathSync(os.tmpdir()));
+    }
+  },
+);
+
+test(
+  "real updater signature verifies and changed bytes are rejected",
+  { skip: !process.env.PCTWEAKER_TEST_ASSET },
+  () => {
+    const file = process.env.PCTWEAKER_TEST_ASSET;
+    assert.ok(verifyUpdater(file, conf.plugins.updater.pubkey));
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pctweaker-verify-"));
+    try {
+      const changed = path.join(dir, "changed.exe");
+      fs.copyFileSync(file, changed);
+      fs.copyFileSync(file + ".sig", changed + ".sig");
+      fs.appendFileSync(changed, "modified");
+      assert.throws(() => verifyUpdater(changed, conf.plugins.updater.pubkey));
+    } finally {
+      removeVerificationDirectory(dir, fs.realpathSync(os.tmpdir()));
+    }
+  },
+);

--- a/scripts/verify-authenticode.ps1
+++ b/scripts/verify-authenticode.ps1
@@ -1,0 +1,50 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string[]]$Path,
+    [string]$ExpectedPublisher = 'Aurelio Avila',
+    [string]$SignToolPath = $env:SIGNTOOL_PATH
+)
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+if (-not $SignToolPath) {
+    $command = Get-Command signtool.exe -ErrorAction SilentlyContinue
+    if ($command) { $SignToolPath = $command.Source }
+    else {
+        $sdk = Join-Path ${env:ProgramFiles(x86)} 'Windows Kits/10/bin'
+        $SignToolPath = Get-ChildItem -LiteralPath $sdk -Filter signtool.exe -Recurse |
+            Where-Object { $_.Directory.Name -eq 'x64' } |
+            Sort-Object FullName -Descending | Select-Object -First 1 -ExpandProperty FullName
+    }
+}
+if (-not $SignToolPath -or -not (Test-Path -LiteralPath $SignToolPath -PathType Leaf)) {
+    throw 'Windows SDK SignTool is required. Set SIGNTOOL_PATH to its full path.'
+}
+foreach ($item in $Path) {
+    $file = Get-Item -LiteralPath $item
+    if ($file.PSIsContainer -or $file.Extension -notin @('.exe', '.msi', '.dll')) {
+        throw "Expected an EXE, MSI or DLL: $item"
+    }
+    $hash = (Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256).Hash
+    $signature = Get-AuthenticodeSignature -LiteralPath $file.FullName
+    if ($signature.Status -ne 'Valid' -or -not $signature.SignerCertificate) {
+        throw "Authenticode verification failed ($($signature.Status)): $item"
+    }
+    $publisher = $signature.SignerCertificate.GetNameInfo(
+        [System.Security.Cryptography.X509Certificates.X509NameType]::SimpleName, $false)
+    if ($publisher -cne $ExpectedPublisher) { throw "Unexpected publisher '$publisher': $item" }
+    if (-not $signature.TimeStamperCertificate) { throw "Missing trusted timestamp: $item" }
+    & $SignToolPath verify /pa /all /v /tw $file.FullName | Out-Host
+    if ($LASTEXITCODE -ne 0) { throw "SignTool failed or warned for: $item" }
+    if ((Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256).Hash -ne $hash) {
+        throw "File changed during verification: $item"
+    }
+    [pscustomobject]@{
+        File = $file.Name
+        SHA256 = $hash.ToLowerInvariant()
+        Status = 'Valid'
+        Publisher = $publisher
+        SignerThumbprint = $signature.SignerCertificate.Thumbprint
+        TimestampSubject = $signature.TimeStamperCertificate.Subject
+    }
+}

--- a/scripts/verify-published-release.ps1
+++ b/scripts/verify-published-release.ps1
@@ -1,0 +1,41 @@
+[CmdletBinding()]
+param([string]$Tag)
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+. "$PSScriptRoot/release-safety.ps1"
+if ($Tag) { Assert-ReleaseTag -Tag $Tag }
+$endpoint = 'repos/AurelioAvila/pc-tweaker-app/releases/latest'
+if ($Tag) { $endpoint = 'repos/AurelioAvila/pc-tweaker-app/releases/tags/' + [uri]::EscapeDataString($Tag) }
+$json = & gh api $endpoint
+if ($LASTEXITCODE -ne 0) { throw 'Could not retrieve release metadata.' }
+$release = $json | ConvertFrom-Json
+Assert-ReleaseTag -Tag $release.tag_name
+if ($release.draft -or $release.prerelease) { throw 'Only stable, published releases may reach WinGet.' }
+$installers = @($release.assets | Where-Object { $_.name -match '\.(exe|msi)$' })
+if (@($installers | Where-Object { $_.name -match '_x64-setup\.exe$' }).Count -ne 1 -or
+    @($installers | Where-Object { $_.name -match '\.msi$' }).Count -lt 1) {
+    throw 'Expected one versioned x64 setup and at least one MSI.'
+}
+$tempRoot = (Resolve-Path -LiteralPath ([IO.Path]::GetTempPath())).ProviderPath
+$directory = [IO.Path]::GetFullPath((Join-Path $tempRoot ('pctweaker-release-' + [guid]::NewGuid())))
+New-Item -ItemType Directory -Path $directory | Out-Null
+try {
+    foreach ($asset in $installers) {
+        if ($asset.name -notmatch '^[A-Za-z0-9._-]+$' -or $asset.digest -notmatch '^sha256:[a-fA-F0-9]{64}$') {
+            throw 'Unsafe asset name or missing GitHub SHA-256 digest.'
+        }
+        $file = Join-Path $directory $asset.name
+        Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $file
+        $digest = 'sha256:' + (Get-FileHash -LiteralPath $file -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($digest -ne $asset.digest) { throw "GitHub digest mismatch: $($asset.name)" }
+        & "$PSScriptRoot/verify-authenticode.ps1" -Path $file | Out-Host
+    }
+    Assert-ReleaseTag -Tag $release.tag_name
+    if ($env:GITHUB_OUTPUT) { "tag=$($release.tag_name)" | Out-File -LiteralPath $env:GITHUB_OUTPUT -Append -Encoding utf8 }
+    Write-Output "Verified release: $($release.tag_name)"
+} finally {
+    # Resolve again immediately before deletion; reject root, siblings and links.
+    $resolvedDirectory = (Resolve-Path -LiteralPath $directory).ProviderPath
+    Assert-TemporaryDirectory -ResolvedDirectory $resolvedDirectory -ExpectedDirectory $directory -TempRoot $tempRoot
+    Remove-Item -LiteralPath $resolvedDirectory -Recurse -Force
+}

--- a/scripts/verify-updater.mjs
+++ b/scripts/verify-updater.mjs
@@ -1,0 +1,47 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+// Tauri wraps the standard minisign public key and detached signature in base64.
+// Verification never accesses a private key or opens a signing session.
+export function verifyUpdater(file, encodedPublicKey) {
+  const temporaryRoot = fs.realpathSync(os.tmpdir());
+  const directory = fs.mkdtempSync(path.join(temporaryRoot, "pctweaker-verify-"));
+  try {
+    const signature = fs.readFileSync(file + ".sig", "utf8").trim();
+    for (const value of [signature, encodedPublicKey]) {
+      if (!value || !/^[A-Za-z0-9+/]+={0,2}$/.test(value)) {
+        throw new Error("Missing or malformed Tauri updater signature/public key.");
+      }
+    }
+    const signaturePath = path.join(directory, "signature.minisig");
+    const publicKeyPath = path.join(directory, "public.key");
+    fs.writeFileSync(signaturePath, Buffer.from(signature, "base64"));
+    fs.writeFileSync(publicKeyPath, Buffer.from(encodedPublicKey, "base64"));
+    execFileSync(
+      process.env.MINISIGN_PATH || "minisign",
+      ["-V", "-m", file, "-x", signaturePath, "-p", publicKeyPath],
+      { stdio: "inherit" },
+    );
+    return signature;
+  } finally {
+    removeVerificationDirectory(directory, temporaryRoot);
+  }
+}
+
+export function removeVerificationDirectory(directory, temporaryRoot) {
+  const resolved = fs.realpathSync(directory);
+  const root = fs.realpathSync(temporaryRoot);
+  if (
+    !path.isAbsolute(directory) ||
+    fs.lstatSync(directory).isSymbolicLink() ||
+    !fs.lstatSync(directory).isDirectory() ||
+    resolved !== path.resolve(directory) ||
+    path.dirname(resolved) !== root ||
+    !/^pctweaker-verify-[A-Za-z0-9]{6}$/.test(path.basename(resolved))
+  ) {
+    throw new Error("Unsafe updater verification cleanup target.");
+  }
+  fs.rmSync(resolved, { recursive: true, force: true });
+}


### PR DESCRIPTION
Stop uploading unsigned CI verification installers. Require publisher/timestamp verification for stable aliases and WinGet, and verify both installer updater signatures before preparing latest.json. Keep local builds and existing releases unchanged. Four regression tests passed, including real v1.10.3 updater verification and tampered-byte rejection. Fresh v1.10.3 downloads and aliases passed API digest and Authenticode verification. Workflow lint passed. No app UI, badges, donations, signing credentials or release assets changed.