### PR TITLE
Verify the actual PC Tweaker executable in release preparation

### DIFF
--- a/scripts/make-latest-json.mjs
+++ b/scripts/make-latest-json.mjs
@@ -70,7 +70,7 @@ const msis = fs.readdirSync(msiDir).filter((file) => file.includes(`_${version}_
 if (msis.length !== 1) throw new Error("Expected exactly one current MSI installer.");
 const releaseDir = path.join(root, "src-tauri", "target", "release");
 const binaries = [
-  path.join(releaseDir, "pc-tweaker-app.exe"),
+  path.join(releaseDir, "tauri-app.exe"),
   ...fs.readdirSync(releaseDir).filter((file) => file.endsWith(".dll")).map((file) => path.join(releaseDir, file)),
   path.join(nsisDir, setup),
   path.join(msiDir, msis[0]),

--- a/scripts/release-verification.test.mjs
+++ b/scripts/release-verification.test.mjs
@@ -48,7 +48,7 @@ test(
       fs.mkdirSync(msi, { recursive: true });
       fs.writeFileSync(path.join(dir, "src-tauri/tauri.conf.json"), JSON.stringify(conf));
       fs.writeFileSync(path.join(dir, "notes.md"), "Verification fixture.");
-      fs.writeFileSync(path.join(release, "pc-tweaker-app.exe"), "unsigned");
+      fs.writeFileSync(path.join(release, "tauri-app.exe"), "unsigned");
       fs.writeFileSync(path.join(nsis, `Test_${conf.version}_x64-setup.exe`), "unsigned");
       fs.writeFileSync(
         path.join(nsis, `Test_${conf.version}_x64-setup.exe.sig`),


### PR DESCRIPTION
The release verifier used the product label as the executable filename, but Cargo builds tauri-app.exe. Point verification and its unsigned-fixture test at the real binary so signed release preparation can complete without weakening the signature checks.