### PR TITLE
Refresh Scan results and add 12/24-hour RAM cleanup

### DIFF
--- a/backend/src/emails/layout.ts
+++ b/backend/src/emails/layout.ts
@@ -48,6 +48,8 @@ export function escapeHtml(value: string): string {
 }
 
 const DEFAULT_ACCENT = "#ff5500";
+// Secondary text remains readable on the dark email surface (WCAG AA).
+export const EMAIL_MUTED_TEXT = "#9ca3af";
 const DEFAULT_PRODUCT = "PC Tweaker";
 const DEFAULT_SITE = "https://pctweaker.app";
 const DEFAULT_LOGO = "https://pctweaker.app/logo.png";
@@ -64,7 +66,7 @@ export function bulletRow(accent: string, text: string): string {
 /** A two-column key/value row, for the receipt block. */
 export function detailRow(label: string, value: string): string {
   return `              <tr>
-                <td style="font-size:13px; color:#5b5f66; padding:4px 0;">${escapeHtml(label)}</td>
+                <td style="font-size:13px; color:${EMAIL_MUTED_TEXT}; padding:4px 0;">${escapeHtml(label)}</td>
                 <td style="font-size:13px; color:#e5e7eb; padding:4px 0; text-align:right;">${escapeHtml(value)}</td>
               </tr>`;
 }
@@ -97,7 +99,7 @@ export function emailShell({
     ? `
         <tr>
           <td style="padding:8px 40px 0; text-align:center;">
-            <p style="margin:0; font-size:13px; color:#5b5f66;">${escapeHtml(note)}</p>
+            <p style="margin:0; font-size:13px; color:${EMAIL_MUTED_TEXT}; line-height:1.6;">${escapeHtml(note)}</p>
           </td>
         </tr>`
     : "";
@@ -135,9 +137,9 @@ export function emailShell({
 ${bodyHtml}${button}${noteRow}${afterActionHtml}
         <tr>
           <td style="padding:32px 40px 40px; text-align:center;">
-            <p style="margin:0; font-size:13px; color:#5b5f66; line-height:1.6;">
+            <p style="margin:0; font-size:13px; color:${EMAIL_MUTED_TEXT}; line-height:1.6;">
               ${footerNote ? `${escapeHtml(footerNote)}<br>` : ""}
-              ${escapeHtml(productName)} &middot; <a href="${escapeHtml(siteUrl)}" style="color:#5b5f66;">pctweaker.app</a>
+              ${escapeHtml(productName)} &middot; <a href="${escapeHtml(siteUrl)}" style="color:${EMAIL_MUTED_TEXT};">pctweaker.app</a>
             </p>
           </td>
         </tr>

--- a/backend/src/emails/pro-welcome.ts
+++ b/backend/src/emails/pro-welcome.ts
@@ -10,7 +10,7 @@
  */
 
 /** The per-product words and colours the shared layout is filled with. */
-import { bulletRow, detailRow, emailShell } from "./layout";
+import { bulletRow, detailRow, emailShell, EMAIL_MUTED_TEXT } from "./layout";
 
 export type ProductBrand = {
   /** Shown in the subject line and the footer, e.g. "PC Tweaker Pro". */
@@ -137,7 +137,7 @@ export function proWelcomeHtml({ product, firstName, email, plan, priceLabel, re
 
         <tr>
           <td style="padding:28px 40px 0;">
-            <div style="font-size:13px; font-weight:700; letter-spacing:0.1em; text-transform:uppercase; color:#5b5f66; margin-bottom:16px;">What you've unlocked</div>
+            <div style="font-size:13px; font-weight:700; letter-spacing:0.1em; text-transform:uppercase; color:${EMAIL_MUTED_TEXT}; margin-bottom:16px;">What you've unlocked</div>
             <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
 ${brand.highlights.map((h) => bulletRow(brand.accent, h)).join("\n")}
             </table>

--- a/backend/test/email-contrast.test.mjs
+++ b/backend/test/email-contrast.test.mjs
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EMAIL_MUTED_TEXT, emailShell, detailRow } from '../dist/emails/layout.js';
+import { proWelcomeHtml } from '../dist/emails/pro-welcome.js';
+
+function luminance(hex) {
+  const channels = hex.slice(1).match(/../g).map(value => parseInt(value, 16) / 255)
+    .map(value => value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4);
+  return channels[0] * 0.2126 + channels[1] * 0.7152 + channels[2] * 0.0722;
+}
+
+test('secondary email text meets AA contrast on both dark surfaces', () => {
+  for (const background of ['#050506', '#0a0a0c']) {
+    assert.ok((luminance(EMAIL_MUTED_TEXT) + 0.05) / (luminance(background) + 0.05) >= 4.5);
+  }
+});
+
+test('account notes, receipt labels and purchase headings use readable text', () => {
+  const shell = emailShell({ eyebrow: 'Account', headline: 'Check your email', intro: 'Continue securely.', note: 'This link expires.', footerNote: 'Contact support.' });
+  const receipt = proWelcomeHtml({ firstName: 'Aurelio', email: 'test@example.com', plan: 'annual', priceLabel: 'EUR 24.00', renewsOn: 'September 7, 2027' });
+  for (const html of [shell, receipt, detailRow('Plan', 'Annual')]) {
+    assert.ok(html.includes(`color:${EMAIL_MUTED_TEXT}`));
+    assert.ok(!html.includes('#5b5f66'));
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pc-tweaker-app",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pc-tweaker-app",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pc-tweaker-app",
   "private": true,
-  "version": "1.11.0",
+  "version": "1.12.0",
   "license": "UNLICENSED",
   "type": "module",
   "scripts": {

--- a/scripts/test-scan.ts
+++ b/scripts/test-scan.ts
@@ -1,0 +1,51 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { collectScan, readLastScan } from "../src/scan-runner";
+
+test("scan reads fresh inventory and completes hardware advice before returning", async () => {
+  const calls: string[] = [];
+  const progress: number[] = [];
+  const result = await collectScan(
+    async <T>(command: string) => {
+      calls.push(command);
+      return [] as T;
+    },
+    (p) => progress.push(p),
+  );
+  assert.equal(new Set(calls).size, 4);
+  assert.equal(result.partial, false);
+  assert.deepEqual(progress, [25, 100]);
+});
+test("a failed optional probe stays unavailable rather than becoming an empty clean result", async () => {
+  const result = await collectScan(
+    async <T>(command: string) => {
+      if (command === "advise_tweaks") throw Error("Access denied");
+      return [] as T;
+    },
+    () => {},
+  );
+  assert.equal(result.partial, true);
+  assert.equal(result.advice, null);
+});
+test("failed inventory aborts the scan rather than reusing old tweak states", async () => {
+  await assert.rejects(
+    collectScan(
+      async () => {
+        throw Error("Unavailable");
+      },
+      () => {},
+    ),
+  );
+});
+test("last scan rejects corrupt, future or incomplete stored data", () => {
+  for (const value of [
+    "invalid",
+    "null",
+    "{}",
+    JSON.stringify({ at: Date.now() + 60000, partial: false }),
+  ]) {
+    assert.equal(readLastScan(value), null);
+  }
+  const valid = { at: Date.now() - 1000, partial: true };
+  assert.deepEqual(readLastScan(JSON.stringify(valid)), valid);
+});

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-app"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-app"
-version = "1.11.0"
+version = "1.12.0"
 description = "Real Windows tweaks with automatic one-click rollback"
 authors = ["Aurelio Avila"]
 license-file = "../LICENSE"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "pc-tweaker-app",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "identifier": "com.aurel.pc-tweaker-app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/components/health.tsx
+++ b/src/components/health.tsx
@@ -44,7 +44,11 @@ type HealthComparison = {
   categories: CategoryChange[];
   structuralChange: boolean;
 };
-type HealthResult = { report: HealthReport; ts: number; comparison: HealthComparison | null };
+export type HealthResult = {
+  report: HealthReport;
+  ts: number;
+  comparison: HealthComparison | null;
+};
 type HealthSnapshot = { ts: number; overall: number };
 export type BaselineRun = {
   ts: number;

--- a/src/components/scan.tsx
+++ b/src/components/scan.tsx
@@ -1,3 +1,4 @@
+import { collectScan, LAST_SCAN_KEY, readLastScan, type LastScan } from "../scan-runner";
 import { ToolHeader } from "./tool-section";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
@@ -190,12 +191,20 @@ export function ScanPanel({
   const [beforeRun, setBeforeRun] = useState<BaselineRun | null>(null);
   const [afterRun, setAfterRun] = useState<BaselineRun | null>(null);
   const [measuring, setMeasuring] = useState(false);
-  const scanTimer = useRef<number | null>(null);
-
-  const SCAN_DURATION_MS = 4200;
-  const scanStep = Math.min(4, Math.floor((scanPct / 100) * 4));
-
+  const scanRun = useRef(0);
+  const scanAnimation = useRef<number | null>(null);
+  const [snapshot, setSnapshot] = useState<{ tweaks: TweakInfo[]; cleanup: CleanupInfo[] } | null>(
+    null,
+  );
+  const [lastScan, setLastScan] = useState<LastScan | null>(() => {
+    try {
+      return readLastScan(localStorage.getItem(LAST_SCAN_KEY));
+    } catch {
+      return null;
+    }
+  });
   const steps = [s.scan.stepPerformance, s.scan.stepPrivacy, s.scan.stepGaming, s.scan.stepJunk];
+  const scanStep = Math.min(4, Math.floor(scanPct / 25));
 
   // Fixable now = anything the user can actually apply today: every free
   // tweak/cleanup, plus Pro ones too once they're unlocked. Locked = Pro
@@ -219,19 +228,22 @@ export function ScanPanel({
       .then((ids) => setScanIds(new Set(ids)))
       .catch(() => setScanIds(new Set()));
   }, []);
-  const scanRelevant = (t: TweakInfo) => scanIds?.has(t.id) ?? false;
+
   const fixableIssues: ScanIssue[] = useMemo(() => {
-    const fromTweaks = tweaks
+    const fromTweaks = (snapshot?.tweaks ?? tweaks)
       .filter(
         (t) =>
-          scanRelevant(t) && !t.applied && (isPro || !t.requires_pro) && t.id !== "turbo_boost",
+          (scanIds?.has(t.id) ?? false) &&
+          !t.applied &&
+          (isPro || !t.requires_pro) &&
+          t.id !== "turbo_boost",
       )
       .map((t) => ({
         kind: "tweak" as const,
         id: t.id,
         ...textFor(s.tweaks, t.id, t.name, t.description),
       }));
-    const fromCleanup = cleanupTargets
+    const fromCleanup = (snapshot?.cleanup ?? cleanupTargets)
       .filter((c) => isPro || !c.requires_pro)
       .map((c) => ({
         kind: "cleanup" as const,
@@ -239,21 +251,22 @@ export function ScanPanel({
         ...textFor(s.cleanup, c.id, c.name, c.description),
       }));
     return [...fromTweaks, ...fromCleanup];
-  }, [tweaks, cleanupTargets, isPro, s, scanIds]);
+  }, [tweaks, cleanupTargets, isPro, s, scanIds, snapshot]);
 
   const lockedIssues = useMemo(
     () =>
       isPro
         ? []
-        : tweaks
-            .filter((t) => scanRelevant(t) && !t.applied && t.requires_pro)
+        : (snapshot?.tweaks ?? tweaks)
+            .filter((t) => (scanIds?.has(t.id) ?? false) && !t.applied && t.requires_pro)
             .map((t) => ({ id: t.id, ...textFor(s.tweaks, t.id, t.name, t.description) })),
-    [tweaks, isPro, s],
+    [tweaks, isPro, s, scanIds, snapshot],
   );
 
   useEffect(() => {
     return () => {
-      if (scanTimer.current) window.clearInterval(scanTimer.current);
+      scanRun.current += 1;
+      if (scanAnimation.current !== null) window.clearInterval(scanAnimation.current);
     };
   }, []);
 
@@ -270,42 +283,58 @@ export function ScanPanel({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [externalScanSignal]);
 
-  function startScan() {
+  async function startScan() {
+    if (phase === "scanning" || fixing) return;
+    const run = ++scanRun.current;
     setPhase("scanning");
     setScanPct(0);
-
-    // Profile the machine while the progress ring runs, so the verdicts are
-    // ready by the time the results appear. A failure here is not fatal: the
-    // advice map stays empty and every issue is offered exactly as before.
-    const adviceReady = invoke<TweakAdvice[]>("advise_tweaks", {
-      ids: fixableIssues.map((i) => i.id),
-    })
-      .then((list) => Object.fromEntries(list.map((a) => [a.id, a])) as Record<string, TweakAdvice>)
-      .catch(() => ({}) as Record<string, TweakAdvice>);
-
-    const start = performance.now();
-    scanTimer.current = window.setInterval(() => {
-      const elapsed = performance.now() - start;
-      const pct = Math.min(100, Math.round((elapsed / SCAN_DURATION_MS) * 100));
-      setScanPct(pct);
-      if (pct >= 100) {
-        if (scanTimer.current) window.clearInterval(scanTimer.current);
-        void adviceReady.then((map) => {
-          setAdvice(map);
-          // Pre-tick only what this PC actually benefits from. Anything the
-          // hardware argues against stays listed but unticked, so "Fix all"
-          // can never quietly apply something that costs the user battery
-          // life or Start-menu search on their particular machine.
-          const initialChecked: Record<string, boolean> = {};
-          fixableIssues.forEach((issue) => {
-            const verdict = map[issue.id]?.verdict;
-            initialChecked[issue.id] = verdict !== "notrecommended" && verdict !== "unsupported";
-          });
-          setChecked(initialChecked);
-          setPhase("results");
+    // Restore the staged visual presentation, but never finish before the reads settle.
+    const started = performance.now();
+    scanAnimation.current = window.setInterval(() => {
+      if (scanRun.current !== run) return;
+      setScanPct(Math.min(95, Math.round(((performance.now() - started) / 4200) * 100)));
+    }, 40);
+    try {
+      const [result] = await Promise.all([
+        collectScan(invoke, () => {}),
+        new Promise<void>((resolve) => window.setTimeout(resolve, 4200)),
+      ]);
+      if (scanRun.current !== run) return;
+      const ids = new Set(result.ids);
+      setScanIds(ids);
+      setSnapshot({ tweaks: result.tweaks, cleanup: result.cleanup });
+      const map = Object.fromEntries((result.advice ?? []).map((a) => [a.id, a]));
+      setAdvice(map);
+      const initialChecked: Record<string, boolean> = {};
+      result.tweaks
+        .filter((t) => ids.has(t.id) && !t.applied && (isPro || !t.requires_pro))
+        .forEach((t) => {
+          initialChecked[t.id] = map[t.id]?.verdict === "recommended";
         });
+      // Cleanup availability is not evidence of junk; destructive cleanup is opt-in.
+      result.cleanup.forEach((c) => {
+        initialChecked[c.id] = false;
+      });
+      setChecked(initialChecked);
+      setScanPct(100);
+      const completed = { at: Date.now(), partial: result.partial };
+      setLastScan(completed);
+      try {
+        localStorage.setItem(LAST_SCAN_KEY, JSON.stringify(completed));
+      } catch {
+        /* Session display still works. */
       }
-    }, 60);
+      setPhase("results");
+    } catch {
+      if (scanRun.current !== run) return;
+      setPhase("idle");
+      pushToast("error", s.scan.scanFailed);
+    } finally {
+      if (scanAnimation.current !== null && scanRun.current === run) {
+        window.clearInterval(scanAnimation.current);
+        scanAnimation.current = null;
+      }
+    }
   }
 
   /** Ids the hardware actually argues for, in list order. */
@@ -391,6 +420,7 @@ export function ScanPanel({
     }
 
     await onFixed();
+    setSnapshot(null);
 
     if (before) {
       setMeasuring(true);
@@ -428,6 +458,12 @@ export function ScanPanel({
         icon={<MagnifierIcon className="h-5 w-5" />}
       />
 
+      <p className="tool-scan-last text-xs text-ink-3" aria-live="polite">
+        {lastScan
+          ? format(s.scan.lastScan, { time: new Date(lastScan.at).toLocaleString() })
+          : s.scan.neverScanned}
+        {lastScan?.partial && <span className="block mt-1">{s.scan.partialScan}</span>}
+      </p>
       {phase === "idle" && (
         <>
           <button
@@ -524,9 +560,7 @@ export function ScanPanel({
             {steps.map((label, i) => (
               <li
                 key={label}
-                className={`flex items-center gap-2 transition-opacity duration-300 ${
-                  i < scanStep ? "text-ok opacity-100" : "text-ink-3 opacity-40"
-                }`}
+                className={`flex items-center gap-2 transition-opacity duration-300 ${i < scanStep ? "text-ok opacity-100" : "text-ink-3 opacity-40"}`}
               >
                 <span className="w-4">{i < scanStep ? "✓" : "…"}</span>
                 {label}

--- a/src/components/tool-surfaces.css
+++ b/src/components/tool-surfaces.css
@@ -545,15 +545,20 @@
 .tool-scan-panel .tool-header {
   margin-bottom: 17px;
 }
+.tool-scan-panel > .tool-scan-last {
+  grid-row: 2;
+  margin: 0 0 16px;
+  overflow-wrap: anywhere;
+}
 .tool-scan-panel[data-phase="idle"] > .tool-scan-launch {
   grid-column: 1;
-  grid-row: 2 / 4;
+  grid-row: 3 / 5;
   margin: 0;
   justify-self: center;
 }
 .tool-scan-panel[data-phase="idle"] > .tool-machine-strip {
   grid-column: 2;
-  grid-row: 2;
+  grid-row: 3;
   margin: 0;
   align-self: end;
 }
@@ -567,19 +572,19 @@
 }
 .tool-scan-panel[data-phase="idle"] > .tool-scan-context {
   grid-column: 2;
-  grid-row: 3;
+  grid-row: 4;
   margin: 9px 0 0;
   align-self: start;
   text-align: left;
 }
 .tool-scan-panel[data-phase="scanning"] > .tool-scan-progress {
   grid-column: 1;
-  grid-row: 2;
+  grid-row: 3;
   justify-self: center;
 }
 .tool-scan-panel[data-phase="scanning"] > .tool-scan-steps {
   grid-column: 2;
-  grid-row: 2;
+  grid-row: 3;
   margin: 0;
   font-size: 12px;
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -481,6 +481,15 @@ export interface Strings {
     signInRequired: string;
   };
   scan: {
+    lastScan: string;
+    neverScanned: string;
+    extraChecks: string;
+    checksHint: string;
+    unavailable: string;
+    startupSummary: string;
+    tasksSummary: string;
+    partialScan: string;
+    scanFailed: string;
     title: string;
     subtitle: string;
     startLabel: string;
@@ -1444,6 +1453,16 @@ const it: Strings = {
     signInRequired: "Accedi o crea un account per salvare le configurazioni.",
   },
   scan: {
+    lastScan: "Ultima scansione: {time}",
+    neverScanned: "Nessuna scansione completata",
+    extraChecks: "Controlli aggiuntivi",
+    checksHint:
+      "Letture del sistema: nessuna modifica automatica. Apri una categoria per vedere i dettagli.",
+    unavailable: "Controllo non disponibile",
+    startupSummary: "{enabled} attivi · {orphaned} collegamenti mancanti",
+    tasksSummary: "{enabled} attività di avvio attive",
+    partialScan: "Risultati parziali: alcuni controlli non sono disponibili.",
+    scanFailed: "Scansione non riuscita. Riprova.",
     title: "Scansione rapida",
     subtitle: "Controlla lo stato del PC e trova ottimizzazioni non ancora attive, in un click.",
     startLabel: "SCAN",
@@ -2739,6 +2758,16 @@ const en: Strings = {
     signInRequired: "Sign in or create an account to save configurations.",
   },
   scan: {
+    lastScan: "Last scan: {time}",
+    neverScanned: "No completed scan yet",
+    extraChecks: "Additional checks",
+    checksHint:
+      "System readings only: nothing is changed automatically. Expand a category to inspect the evidence.",
+    unavailable: "Check unavailable",
+    startupSummary: "{enabled} enabled · {orphaned} missing targets",
+    tasksSummary: "{enabled} enabled startup tasks",
+    partialScan: "Partial results: some checks are unavailable.",
+    scanFailed: "Scan failed. Please try again.",
     title: "Quick scan",
     subtitle:
       "Checks your PC's status and finds optimizations that aren't active yet, in one click.",
@@ -4038,6 +4067,16 @@ const fr: Strings = {
     signInRequired: "Connectez-vous ou creez un compte pour enregistrer des configurations.",
   },
   scan: {
+    lastScan: "Dernière analyse : {time}",
+    neverScanned: "Aucune analyse terminée",
+    extraChecks: "Vérifications supplémentaires",
+    checksHint:
+      "Lectures du système uniquement : aucune modification automatique. Développez une catégorie pour voir les détails.",
+    unavailable: "Vérification indisponible",
+    startupSummary: "{enabled} actifs · {orphaned} cibles manquantes",
+    tasksSummary: "{enabled} tâches de démarrage actives",
+    partialScan: "Résultats partiels : certaines vérifications sont indisponibles.",
+    scanFailed: "Échec de l’analyse. Réessayez.",
     title: "Analyse rapide",
     subtitle:
       "Vérifie l'état de votre PC et trouve les optimisations pas encore actives, en un clic.",
@@ -5342,6 +5381,16 @@ const es: Strings = {
     signInRequired: "Inicia sesión o crea una cuenta para guardar configuraciones.",
   },
   scan: {
+    lastScan: "Último análisis: {time}",
+    neverScanned: "Aún no hay análisis completados",
+    extraChecks: "Comprobaciones adicionales",
+    checksHint:
+      "Solo lecturas del sistema: no se cambia nada automáticamente. Abre una categoría para ver los detalles.",
+    unavailable: "Comprobación no disponible",
+    startupSummary: "{enabled} activos · {orphaned} destinos ausentes",
+    tasksSummary: "{enabled} tareas de inicio activas",
+    partialScan: "Resultados parciales: algunas comprobaciones no están disponibles.",
+    scanFailed: "El análisis falló. Inténtalo de nuevo.",
     title: "Análisis rápido",
     subtitle:
       "Comprueba el estado de tu PC y encuentra optimizaciones que aún no están activas, en un clic.",
@@ -6651,6 +6700,16 @@ const de: Strings = {
       "Melden Sie sich an oder erstellen Sie ein Konto, um Konfigurationen zu speichern.",
   },
   scan: {
+    lastScan: "Letzter Scan: {time}",
+    neverScanned: "Noch kein abgeschlossener Scan",
+    extraChecks: "Zusätzliche Prüfungen",
+    checksHint:
+      "Nur Systemabfragen: Es wird nichts automatisch geändert. Öffne eine Kategorie für Details.",
+    unavailable: "Prüfung nicht verfügbar",
+    startupSummary: "{enabled} aktiviert · {orphaned} fehlende Ziele",
+    tasksSummary: "{enabled} aktivierte Autostart-Aufgaben",
+    partialScan: "Teilergebnisse: Einige Prüfungen sind nicht verfügbar.",
+    scanFailed: "Scan fehlgeschlagen. Bitte erneut versuchen.",
     title: "Schnellscan",
     subtitle:
       "Prüft den Zustand deines PCs und findet noch nicht aktive Optimierungen, mit einem Klick.",
@@ -7958,6 +8017,16 @@ const pt: Strings = {
     signInRequired: "Entre ou crie uma conta para salvar configurações.",
   },
   scan: {
+    lastScan: "Última análise: {time}",
+    neverScanned: "Nenhuma análise concluída",
+    extraChecks: "Verificações adicionais",
+    checksHint:
+      "Apenas leituras do sistema: nada é alterado automaticamente. Abra uma categoria para ver os detalhes.",
+    unavailable: "Verificação indisponível",
+    startupSummary: "{enabled} ativos · {orphaned} destinos ausentes",
+    tasksSummary: "{enabled} tarefas de arranque ativas",
+    partialScan: "Resultados parciais: algumas verificações estão indisponíveis.",
+    scanFailed: "A análise falhou. Tente novamente.",
     title: "Verificação rápida",
     subtitle:
       "Verifica o estado do seu PC e encontra otimizações que ainda não estão ativas, com um clique.",

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -102,7 +102,7 @@ export function loadColor(pct: number): string {
 }
 
 /** Auto-cleanup choices, in minutes. `0` means "off". */
-export const RAM_AUTO_INTERVALS = [0, 10, 30, 60, 180, 360] as const;
+export const RAM_AUTO_INTERVALS = [0, 10, 30, 60, 180, 360, 720, 1440] as const;
 
 export const RAM_AUTO_STORAGE_KEY = "pc-tweaker-ram-auto";
 

--- a/src/scan-runner.ts
+++ b/src/scan-runner.ts
@@ -1,0 +1,46 @@
+import type { CleanupInfo, TweakAdvice, TweakInfo } from "./types";
+type Call = <T>(command: string, args?: Record<string, unknown>) => Promise<T>;
+
+/** Fresh reads only. A failed optional probe remains unknown, never a clean bill of health. */
+export async function collectScan(call: Call, progress: (percent: number) => void) {
+  const [tweaks, cleanup, ids] = await Promise.all([
+    call<TweakInfo[]>("list_tweaks"),
+    call<CleanupInfo[]>("list_cleanup_targets"),
+    call<string[]>("scan_relevant_ids"),
+  ]);
+  progress(25);
+  const probe = async <T>(command: string, args?: Record<string, unknown>): Promise<T | null> => {
+    try {
+      return await call<T>(command, args);
+    } catch {
+      return null;
+    } finally {
+      progress(100);
+    }
+  };
+  const advice = await probe<TweakAdvice[]>("advise_tweaks", { ids });
+  return {
+    tweaks,
+    cleanup,
+    ids,
+    advice,
+    partial: advice === null,
+  };
+}
+
+export const LAST_SCAN_KEY = "pc-tweaker-last-scan-v1";
+export type LastScan = { at: number; partial: boolean };
+export function readLastScan(raw: string | null): LastScan | null {
+  try {
+    const value = JSON.parse(raw ?? "null");
+    return value &&
+      Number.isFinite(value.at) &&
+      value.at > 0 &&
+      value.at <= Date.now() &&
+      typeof value.partial === "boolean"
+      ? { at: value.at, partial: value.partial }
+      : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Scan results you can revisit

- Quick Scan refreshes Windows tweak and cleanup availability on every run, with the familiar animated progress display.
- See when your last scan completed, including after restarting the app. Incomplete advice is clearly marked.
- Only recommended tweaks are preselected. Cleanup actions remain opt-in.
- Schedule automatic RAM cleanup every 12 or 24 hours, alongside the existing intervals. PC Tweaker must remain running for scheduled cleanup.
- Improved readability in account emails.

Windows installers and application binaries are digitally signed by Aurelio Avila and timestamped. Automatic-update packages also carry the updater signature. Code signing does not guarantee that Windows SmartScreen will never display a warning.
