### PR TITLE
Patch Nodemailer security advisories

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,7 +16,7 @@
         "express-rate-limit": "^7.4.0",
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
-        "nodemailer": "^9.0.3",
+        "nodemailer": "^9.1.1",
         "pg": "^8.12.0",
         "stripe": "^16.9.0"
       },
@@ -1557,9 +1557,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
-      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.1.1.tgz",
+      "integrity": "sha512-izw9mVKFix6YSnC9eLgV6g1opl9DUlRio9ZNcq+Wu9Ujn2UwF+8Nl0B8nz22kEC+CTZCvinkxwJ0DeFbb6NwcQ==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,7 +23,7 @@
     "express-rate-limit": "^7.4.0",
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
-    "nodemailer": "^9.0.3",
+    "nodemailer": "^9.1.1",
     "pg": "^8.12.0",
     "stripe": "^16.9.0"
   },


### PR DESCRIPTION
Updates the backend mail transport to Nodemailer 9.1.1, covering the four open dependency advisories. All 110 backend tests pass, and npm audit reports no known vulnerabilities in this dependency tree. Desktop binaries are unchanged.