### PR TITLE
Release 1.12.1: enforce signed subscription expiry offline

### DIFF
--- a/backend/src/products.ts
+++ b/backend/src/products.ts
@@ -57,7 +57,11 @@ export async function productEntitlement(userId: number | string, product: Produ
       [userId],
     );
     const row = rows[0];
-    return { product, active: isEntitled(row), plan: row?.plan ?? null };
+    return {
+      product, active: isEntitled(row), plan: row?.plan ?? null,
+      expiresAt: row?.plan && PERPETUAL_PLANS.has(row.plan) ? null
+        : row?.pro_expires_at ? new Date(row.pro_expires_at).toISOString() : null,
+    };
   }
   const { rows } = await getPool().query(
     "SELECT plan, expires_at FROM entitlements WHERE user_id = $1 AND product = $2",

--- a/backend/test/pctweaker-expiry.test.mjs
+++ b/backend/test/pctweaker-expiry.test.mjs
@@ -1,0 +1,18 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+process.env.DATABASE_URL='pgmem';
+const {initSchema,getPool}=await import('../dist/db.js');
+const {productEntitlement}=await import('../dist/products.js');
+await initSchema();
+test('PC Tweaker annual entitlement carries its paid expiry and lapses without a webhook',async()=>{
+ const expires=new Date(Date.now()+365*86400000);
+ const {rows}=await getPool().query("INSERT INTO users(email,password_hash,is_pro,plan,pro_expires_at) VALUES('annual-expiry@example.invalid','x',TRUE,'annual',$1) RETURNING id",[expires]);
+ const id=rows[0].id;
+ const active=await productEntitlement(id,'pctweaker');
+ assert.equal(active.active,true);assert.equal(active.expiresAt,expires.toISOString());
+ await getPool().query('UPDATE users SET pro_expires_at=$1 WHERE id=$2',[new Date(Date.now()-1000),id]);
+ assert.equal((await productEntitlement(id,'pctweaker')).active,false);
+ await getPool().query("UPDATE users SET plan='lifetime',pro_expires_at=NULL WHERE id=$1",[id]);
+ const lifetime=await productEntitlement(id,'pctweaker');
+ assert.equal(lifetime.active,true);assert.equal(lifetime.expiresAt,null);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pc-tweaker-app",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pc-tweaker-app",
-      "version": "1.12.0",
+      "version": "1.12.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pc-tweaker-app",
   "private": true,
-  "version": "1.12.0",
+  "version": "1.12.1",
   "license": "UNLICENSED",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-app"
-version = "1.12.0"
+version = "1.12.1"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-app"
-version = "1.12.0"
+version = "1.12.1"
 description = "Real Windows tweaks with automatic one-click rollback"
 authors = ["Aurelio Avila"]
 license-file = "../LICENSE"

--- a/src-tauri/src/license.rs
+++ b/src-tauri/src/license.rs
@@ -73,6 +73,9 @@ pub struct LicensePayload {
     /// measured from this, not from local receipt — a cached-and-replayed
     /// response can't be made to look newer than it actually is.
     pub issued_at: u64,
+    /// Signed paid-period cutoff. Legacy payloads retain the existing freshness limit.
+    #[serde(default)]
+    pub expires_at: Option<u64>,
 }
 
 /// What the server sends: the exact bytes it signed, plus the signature over
@@ -188,6 +191,7 @@ fn is_fresh_at(payload: &LicensePayload, now: u64) -> bool {
     payload.issued_at > 0
         && payload.issued_at <= now.saturating_add(MAX_CLOCK_SKEW_SECS)
         && now.saturating_sub(payload.issued_at) <= GRACE_PERIOD_SECS
+        && payload.expires_at.is_none_or(|expiry| now < expiry)
 }
 
 /// Persists the raw, still-signed response to the app data directory so it
@@ -346,6 +350,7 @@ mod tests {
             plan: Some("monthly".into()),
             product: Some(PRODUCT_ID.into()),
             issued_at: now_secs(),
+            expires_at: None,
         };
         let (json, signature, public_key) = sign_test_payload(&payload);
         assert_eq!(
@@ -362,6 +367,7 @@ mod tests {
             plan: Some("lifetime".into()),
             product: Some(PRODUCT_ID.into()),
             issued_at: now_secs(),
+            expires_at: None,
         };
         let (payload_json, signature, public_key) = sign_test_payload(&payload);
         let response = SignedLicenseResponse {
@@ -390,6 +396,7 @@ mod tests {
             plan: Some("lifetime".into()),
             product: Some("another-product".into()),
             issued_at: now_secs(),
+            expires_at: None,
         };
         for (product, issued_at) in [
             ("another-product", now_secs()),
@@ -426,6 +433,7 @@ mod tests {
             plan: Some("lifetime".into()),
             product: Some("uninstaller".into()),
             issued_at: now_secs(),
+            expires_at: None,
         };
         let (json, signature, public_key) = sign_test_payload(&payload);
         let verified = verify_with_public_key(&json, &signature, &public_key).unwrap();
@@ -474,6 +482,7 @@ mod tests {
             plan: Some("monthly".into()),
             product: Some(PRODUCT_ID.into()),
             issued_at: now_secs(),
+            expires_at: None,
         };
         // Sign it the same way the real verify() expects: payload_json must
         // be exactly what a signature was computed over. Since this test has
@@ -502,6 +511,7 @@ mod tests {
             plan: None,
             product: Some(PRODUCT_ID.into()),
             issued_at: now_secs().saturating_sub(GRACE_PERIOD_SECS + 3600),
+            expires_at: None,
         };
         assert!(!is_fresh(&stale));
     }
@@ -515,6 +525,7 @@ mod tests {
             plan: Some("monthly".into()),
             product: Some(PRODUCT_ID.into()),
             issued_at: now,
+            expires_at: None,
         };
         assert!(is_fresh_at(&payload, now));
         assert!(is_fresh_at(&payload, now + GRACE_PERIOD_SECS));
@@ -536,6 +547,63 @@ mod tests {
         assert!(!store.is_pro_and_fresh());
     }
 
+    #[test]
+    fn paid_period_cuts_off_offline_access_and_renewal_requires_a_new_payload() {
+        let now = 1_800_000_000;
+        for plan in ["monthly", "annual"] {
+            let mut payload = LicensePayload {
+                user_id: "expiry-test".into(),
+                is_pro: true,
+                plan: Some(plan.into()),
+                product: Some(PRODUCT_ID.into()),
+                issued_at: now,
+                expires_at: Some(now + 60),
+            };
+            assert!(is_fresh_at(&payload, now + 59));
+            // Cancellation and unsuccessful renewal do not extend the paid period.
+            assert!(!is_fresh_at(&payload, now + 60));
+            assert!(!is_fresh_at(&payload, now + 61));
+            payload.issued_at = now + 60;
+            payload.expires_at = Some(now + 86400);
+            assert!(is_fresh_at(&payload, now + 61));
+            payload.expires_at = Some(now + GRACE_PERIOD_SECS * 2);
+            assert!(!is_fresh_at(&payload, now + 61 + GRACE_PERIOD_SECS));
+        }
+    }
+
+    #[test]
+    fn signed_expiry_is_verified_and_legacy_caches_remain_bounded() {
+        let now = now_secs();
+        let mut payload = LicensePayload {
+            user_id: "signed-expiry".into(),
+            is_pro: true,
+            plan: Some("annual".into()),
+            product: Some(PRODUCT_ID.into()),
+            issued_at: now,
+            expires_at: Some(now - 1),
+        };
+        let (payload_json, signature, public_key) = sign_test_payload(&payload);
+        let response = SignedLicenseResponse {
+            payload_json,
+            signature,
+        };
+        assert_eq!(verified_fresh_response(&response, &public_key), None);
+        let tampered = response
+            .payload_json
+            .replace(&(now - 1).to_string(), &(now + 86400).to_string());
+        assert_eq!(
+            verify_with_public_key(&tampered, &response.signature, &public_key),
+            Err(VerifyError::SignatureInvalid)
+        );
+        // Lifetime and older signed caches without a cutoff still need periodic refresh.
+        payload.expires_at = None;
+        for plan in ["lifetime", "monthly"] {
+            payload.plan = Some(plan.into());
+            assert!(is_fresh_at(&payload, now));
+            assert!(!is_fresh_at(&payload, now + GRACE_PERIOD_SECS + 1));
+        }
+    }
+
     /// After `delete`, a previously fresh cache must no longer read as Pro —
     /// this is what stops a still-valid cache from one account granting Pro
     /// to whoever logs in next on the same machine.
@@ -550,6 +618,7 @@ mod tests {
                 plan: Some("monthly".into()),
                 product: Some(PRODUCT_ID.into()),
                 issued_at: now_secs(),
+                expires_at: None,
             })
             .unwrap(),
             signature: "irrelevant-for-this-test".into(),

--- a/src-tauri/src/lifetime_tools.rs
+++ b/src-tauri/src/lifetime_tools.rs
@@ -444,6 +444,7 @@ mod tests {
             plan: Some("lifetime".into()),
             product: Some("pctweaker".into()),
             issued_at: 1,
+            expires_at: None,
         };
         assert!(is_lifetime(&payload));
         for plan in [

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "pc-tweaker-app",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "identifier": "com.aurel.pc-tweaker-app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
PC Tweaker 1.12.1 improves subscription validation: signed licenses now include the paid-period expiry, and the desktop app checks that cutoff even while offline. Monthly and annual renewals keep their existing billing settings; Lifetime access is preserved.

- Enforces the signed subscription expiry in native Pro feature checks, alongside the existing three-day offline refresh limit.
- Accepts refreshed licenses after renewal. Turning off renewal preserves access until the paid period ends.
- Preserves compatibility with older signed caches until their existing refresh limit; a fresh license supplies the paid expiry.
- Includes regression coverage for expiry boundaries, renewal, offline freshness, Lifetime compatibility and signature tampering.

Windows application files and installers are digitally signed by Aurelio Avila and timestamped. Automatic update packages also carry the separate updater signature.
