### PR TITLE
Keep code-signing website copy current across releases

### DIFF
--- a/site/src/i18n/dictionary.ts
+++ b/site/src/i18n/dictionary.ts
@@ -214,7 +214,7 @@ export const engDictionary: Dictionary = {
     "subBold": "Make deliberate changes. Keep what works.",
     "sub": " Review Windows settings for gaming, privacy and everyday use. See what each tweak changes, save its previous state and restore supported settings when you need to. Start free. No account required.",
     "cta": "Download Free for Windows",
-    "safetyNote": "PC Tweaker 1.12.0 is code-signed. Our signed Windows installers identify Aurelio Avila as the publisher. Older downloads may be unsigned; check the file's Digital Signatures tab. SmartScreen may still show a warning for a new release.",
+    "safetyNote": "PC Tweaker installers are code-signed. Our signed Windows installers identify Aurelio Avila as the publisher. Older downloads may be unsigned; check the file's Digital Signatures tab. SmartScreen may still show a warning for a new release.",
     "terminalTitle": "Install with Windows Package Manager",
     "terminalCmd": "winget install --id AurelioAvila.PCTweaker --exact",
     "terminalHint": "# install the official PC Tweaker package",
@@ -514,7 +514,7 @@ export const engDictionary: Dictionary = {
       },
       {
         "q": "Is PC Tweaker code-signed?",
-        "a": "PC Tweaker 1.12.0 ships with Windows application and installer signatures from Aurelio Avila and a trusted timestamp. Older releases may be unsigned. A valid signature identifies the publisher and helps detect changed files. The separate update signature verifies update packages. Neither guarantees performance gains or prevents every SmartScreen prompt."
+        "a": "PC Tweaker ships with Windows application and installer signatures from Aurelio Avila and a trusted timestamp. Older releases may be unsigned. A valid signature identifies the publisher and helps detect changed files. The separate update signature verifies update packages. Neither guarantees performance gains or prevents every SmartScreen prompt."
       }
     ]
   },


### PR DESCRIPTION
Remove hardcoded release numbers from the code-signing explanations so the site does not describe an older version after updates. Publisher, timestamp and SmartScreen limitations remain explicit. Site build and SEO checks passed for 14 routes and the 404 page.