### PR TITLE
PC Tweaker 1.12.2: recheck updates when reopening from the tray

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Release verification regression tests
         run: node --test scripts/release-verification.test.mjs
 
+      - name: Updater startup and tray lifecycle
+        run: npm run test:updater
+
       - name: Translations (keys + placeholders across all languages)
         run: npm run check:i18n
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## v1.12.2
+
+- Recheck for updates when reopening the hidden app from the notification area. An update dismissed with Later can be offered again on reopening; concurrent checks and installation attempts are guarded.
+
+## v1.12.1
+
+- Signed PC Tweaker licenses now carry the paid subscription expiry. Native Pro checks enforce that cutoff offline alongside the existing three-day cache freshness limit.
+- Fresh signed licenses reflect renewed periods. Cancellation at period end preserves access through the paid period; Lifetime access is preserved.
+- Older signed caches without an expiry retain their existing freshness limit until refreshed.
+
+Windows binaries and installers are digitally signed by Aurelio Avila and timestamped; automatic updates carry a separate updater signature.
+
+## v1.12.0
+
+- Quick Scan reads current tweak and cleanup availability on every run and records when the last scan completed, including across app restarts. Unavailable advice is marked incomplete.
+- Preserves the animated scan display. Only recommended tweaks are preselected; cleanup stays opt-in.
+- Adds automatic RAM cleanup intervals of 12 and 24 hours. The app must remain running for scheduled cleanup.
+- Improves readability in account emails.
+
+## v1.11.0
+
+- Lifetime includes 12 months of Uninstaller Pro, starting at the first sign-in to Uninstaller with the same account. Existing Lifetime owners are included. The bonus has no automatic renewal and remains separate from standalone Uninstaller licenses.
+- The desktop pricing card and website explain the benefit and activation period.
+- List search fields use one rounded focus indicator and one accessible clear button, without spelling marks on program names.
+
+These releases distribute digitally signed, timestamped Windows application files and installers. Code signing does not guarantee that every SmartScreen warning disappears.
+
 ## v1.10.3
 
 PC Tweaker now stays in the Windows notification area when you close its window, keeping ongoing app features available until you choose to exit.
@@ -447,7 +474,7 @@ update from here on (features, fixes, infra changes) gets an entry —
 this is the single source of truth for "what changed and why," not just
 the git log.
 
-## Unreleased
+## v1.12.2
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pc-tweaker-app",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pc-tweaker-app",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "license": "UNLICENSED",
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pc-tweaker-app",
   "private": true,
-  "version": "1.12.1",
+  "version": "1.12.2",
   "license": "UNLICENSED",
   "type": "module",
   "scripts": {
@@ -13,13 +13,14 @@
     "check:i18n-quality": "node scripts/audit-i18n.mjs",
     "check:rust": "cargo test --manifest-path src-tauri/Cargo.toml",
     "check:native-policy": "node scripts/check-native-policy.mjs",
-    "check": "tsc --noEmit && eslint src && prettier --check \"src/**/*.{ts,tsx,css}\" && npm run check:i18n && npm run check:i18n-quality && npm run check:rust && npm run test:advisor && npm run test:thermals",
+    "check": "tsc --noEmit && eslint src && prettier --check \"src/**/*.{ts,tsx,css}\" && npm run check:i18n && npm run check:i18n-quality && npm run check:rust && npm run test:advisor && npm run test:thermals && npm run test:updater",
     "lint": "eslint src",
     "format": "prettier --write \"src/**/*.{ts,tsx,css}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\"",
     "test:advisor": "node scripts/test-advisor.mjs",
     "test:lifetime-offer": "node scripts/test-lifetime-offer.mjs",
-    "test:thermals": "node scripts/test-thermals.mjs"
+    "test:thermals": "node scripts/test-thermals.mjs",
+    "test:updater": "node scripts/test-updater.mjs"
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.3.0",

--- a/scripts/test-updater.mjs
+++ b/scripts/test-updater.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import vm from "node:vm";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+
+// Exercise the actual component's effects with deterministic event/network adapters.
+const mocks = {
+  react: `export const useState=initial=>h.state(initial); export const useRef=value=>h.ref(value); export const useEffect=fn=>h.effects.push(fn); export const useMemo=fn=>fn();`,
+  "react/jsx-runtime": `export const jsx=(type,props)=>({type,props});export const jsxs=jsx;`,
+  "@tauri-apps/plugin-updater": `export const check=()=>h.check();`,
+  "@tauri-apps/api/event": `export const listen=(event,fn)=>{h.listeners.set(event,fn);return Promise.resolve(()=>h.listeners.delete(event))};`,
+  "@tauri-apps/plugin-process": `export const relaunch=()=>Promise.resolve();`,
+};
+const compiled = await build({
+  entryPoints: [fileURLToPath(new URL("../src/components/ui.tsx", import.meta.url))],
+  bundle: true,
+  write: false,
+  format: "cjs",
+  platform: "node",
+  jsx: "automatic",
+  plugins: [
+    {
+      name: "adapters",
+      setup(build) {
+        build.onResolve({ filter: /^(react(?:\/jsx-runtime)?|@tauri-apps\/)/ }, (args) =>
+          args.path in mocks ? { path: args.path, namespace: "mock" } : undefined,
+        );
+        build.onLoad({ filter: /.*/, namespace: "mock" }, (args) => ({
+          contents: mocks[args.path],
+          loader: "js",
+        }));
+      },
+    },
+  ],
+});
+const h = {
+  values: [],
+  refs: [],
+  effects: [],
+  listeners: new Map(),
+  requests: [],
+  index: 0,
+  refIndex: 0,
+  state(initial) {
+    const i = this.index++;
+    if (!(i in this.values)) this.values[i] = initial;
+    return [this.values[i], (v) => (this.values[i] = v)];
+  },
+  ref(value) {
+    const i = this.refIndex++;
+    return (this.refs[i] ??= { current: value });
+  },
+  check() {
+    return new Promise((resolve, reject) => this.requests.push({ resolve, reject }));
+  },
+};
+const context = vm.createContext({ h, module: { exports: {} } });
+vm.runInContext(compiled.outputFiles[0].text, context);
+const toasts = [];
+const render = () => {
+  h.index = 0;
+  h.refIndex = 0;
+  return context.module.exports.UpdateBanner({
+    s: {
+      updater: {
+        title: "Update {version}",
+        body: "Available",
+        install: "Install",
+        later: "Later",
+        checkFailed: "Check failed: {message}",
+        error: "Error: {message}",
+      },
+    },
+    onToast: (...args) => toasts.push(args),
+  });
+};
+const flush = async () => {
+  for (let i = 0; i < 8; i++) await Promise.resolve();
+};
+render();
+const stop = h.effects[0]();
+assert.equal(h.requests.length, 1, "startup checks for updates");
+h.listeners.get("app-reopened")();
+h.listeners.get("app-reopened")();
+assert.equal(h.requests.length, 1, "reopening during a pending check does not duplicate it");
+let installs = 0,
+  rejectInstall;
+const update = {
+  version: "9.0.0",
+  downloadAndInstall: () => {
+    installs++;
+    return new Promise((resolve, reject) => (rejectInstall = reject));
+  },
+};
+h.requests[0].resolve(update);
+await flush();
+const buttons = (node) =>
+  !node || typeof node !== "object"
+    ? []
+    : [
+        ...(node.type === "button" ? [node] : []),
+        ...[node.props?.children].flat().flatMap(buttons),
+      ];
+let actions = buttons(render());
+actions.find((b) => b.props.children === "Later").props.onClick();
+assert.equal(render(), null, "Later dismisses the current offer");
+h.listeners.get("app-reopened")();
+assert.equal(h.requests.length, 2);
+h.requests[1].resolve(update);
+await flush();
+actions = buttons(render());
+assert.ok(actions.length, "reopening shows the dismissed offer again");
+const install = actions.find((b) => b.props.children === "Install").props.onClick;
+const attempt = install();
+void install();
+assert.equal(installs, 1, "rapid clicks cannot install twice");
+h.listeners.get("app-reopened")();
+assert.equal(h.requests.length, 2, "no concurrent check while installing");
+rejectInstall(Error("network unavailable"));
+await attempt;
+assert.equal(h.values[1], "offer", "failed installation can be retried");
+h.listeners.get("app-reopened")();
+h.requests[2].reject(Error("offline"));
+await flush();
+assert.equal(toasts.length, 2, "installation and check failures are visible");
+h.listeners.get("app-reopened")();
+const old = h.values[0];
+stop();
+h.requests[3].resolve({ version: "10.0.0" });
+await flush();
+assert.equal(h.values[0], old, "late response after unmount cannot update state");
+assert.equal(h.listeners.size, 0, "unmount removes tray listener");
+console.log(
+  "Updater lifecycle passed: startup, tray reopen, dismissal, concurrency, failure and unmount.",
+);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-app"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-app"
-version = "1.12.1"
+version = "1.12.2"
 description = "Real Windows tweaks with automatic one-click rollback"
 authors = ["Aurelio Avila"]
 license-file = "../LICENSE"

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use tauri::{
     menu::{CheckMenuItem, Menu, MenuItem},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
-    Manager,
+    Emitter, Manager,
 };
 use tauri_plugin_dialog::DialogExt;
 
@@ -13,9 +13,13 @@ pub struct BackgroundState {
 
 fn show(app: &tauri::AppHandle) {
     if let Some(window) = app.get_webview_window("main") {
+        let was_hidden = !window.is_visible().unwrap_or(true);
         let _ = window.show();
         let _ = window.unminimize();
         let _ = window.set_focus();
+        if was_hidden && window.is_visible().unwrap_or(false) {
+            let _ = window.emit("app-reopened", ());
+        }
     }
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "pc-tweaker-app",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "identifier": "com.aurel.pc-tweaker-app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
 import { check as checkForUpdate, type Update } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { format, Strings } from "../i18n";
@@ -259,7 +260,7 @@ export function Avatar({
 }
 
 /**
- * Checks GitHub once at startup for a newer signed build and, when one
+ * Checks GitHub at startup and after reopening from the tray for a newer signed build and, when one
  * exists, offers it in a small card next to the toasts. A failed check
  * surfaces as the same brief, auto-dismissing toast used for every other
  * background error — never a blocking popup — so a broken updater is
@@ -280,18 +281,38 @@ export function UpdateBanner({
   const [phase, setPhase] = useState<"offer" | "downloading" | "installing">("offer");
   const [percent, setPercent] = useState(0);
   const [dismissed, setDismissed] = useState(false);
+  const installing = useRef(false);
 
   useEffect(() => {
     let alive = true;
-    checkForUpdate()
-      .then((u) => {
-        if (alive && u) setUpdate(u);
-      })
-      .catch((err) => {
-        if (alive) onToast("error", format(s.updater.checkFailed, { message: String(err) }));
-      });
+    let checking = false;
+    let reopenOffer = false;
+    const check = (reopened = false) => {
+      if (!alive || installing.current) return;
+      reopenOffer ||= reopened;
+      if (checking) return;
+      checking = true;
+      void checkForUpdate()
+        .then((u) => {
+          if (alive && u) {
+            setUpdate(u);
+            if (reopenOffer) setDismissed(false);
+          }
+        })
+        .catch((err) => {
+          if (alive) onToast("error", format(s.updater.checkFailed, { message: String(err) }));
+        })
+        .finally(() => {
+          checking = false;
+          reopenOffer = false;
+        });
+    };
+    check();
+    const unlisten = listen("app-reopened", () => check(true));
+    void unlisten.catch(() => {});
     return () => {
       alive = false;
+      void unlisten.then((stop) => stop()).catch(() => {});
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -299,8 +320,10 @@ export function UpdateBanner({
   if (!update || dismissed) return null;
 
   async function install() {
-    if (!update) return;
+    if (!update || installing.current) return;
+    installing.current = true;
     try {
+      setPercent(0);
       setPhase("downloading");
       let total = 0;
       let received = 0;
@@ -316,6 +339,7 @@ export function UpdateBanner({
       });
       await relaunch();
     } catch (err) {
+      installing.current = false;
       setPhase("offer");
       onToast("error", format(s.updater.error, { message: String(err) }));
     }


### PR DESCRIPTION
PC Tweaker 1.12.2 checks for updates when you reopen the app from the Windows notification area. If you previously chose Later, an available update can be offered again without restarting the app.

- Reopening the hidden app triggers a fresh update check. Installation starts only when you choose Install.
- Repeated reopen events share an in-progress check. Rapid clicks cannot start duplicate installations, and a failed installation can be retried.
- Updated the changelog with the recent subscription-expiry, Quick Scan and Lifetime suite improvements.

Windows application files and installers are digitally signed by Aurelio Avila with a trusted timestamp. Automatic update packages also carry a verified updater signature.

Download the signed Windows installer below, or install through WinGet once Microsoft has approved the new manifest. Existing settings and account entitlements are preserved.
