### PR TITLE
PC Tweaker 1.13.1: verify the connection around TCP tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.13.1
+
+- The two tweaks that change TCP behavior, acknowledgment timing and the congestion provider, now verify the connection before and after applying. If the line stops responding, the setting is restored exactly as it was and the attempt is reported as failed.
+- The check opens a TCP connection to 1.1.1.1, or github.com when that is unreachable, and sends no data about you or your device. It is described in the privacy policy.
+- Select all in Quick Scan no longer selects the changes advised against on your hardware. They stay available individually under their own heading; Deselect all still clears everything.
+
+Windows binaries and installers are digitally signed by Aurelio Avila and timestamped; automatic updates carry a separate updater signature.
+
 ## v1.13.0
 
 - Adds a Lifetime campaign price of €79.99, shown against the €119 list price while a campaign window is open.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,10 +1,20 @@
 # Privacy Policy
 
-Last updated: 2026-08-24
+Last updated: 2026-09-12
 
 PC Tweaker is a desktop application. Windows tweaks, snapshots, rollback data,
 hardware readings and file scans are processed locally on your device. They are
 not uploaded to PC Tweaker.
+
+## Connection check
+
+The two tweaks that change how Windows handles TCP connections
+(acknowledgment timing and the congestion provider) can affect an unusual
+line in ways the setting alone does not predict. When you apply one, the app
+opens a TCP connection to 1.1.1.1 and, if that is unreachable, to github.com,
+before and after the change, purely to confirm the line still works. If it
+stopped working, the app puts the setting back. No data about you or your
+device is sent in that check.
 
 ## Account data
 

--- a/RELEASE-NOTES-1.13.1.md
+++ b/RELEASE-NOTES-1.13.1.md
@@ -1,0 +1,7 @@
+PC Tweaker 1.13.1 adds a connection check to the two tweaks that change how Windows handles TCP connections: acknowledgment timing and the congestion provider. The line is tested before the change and again afterwards. If it stopped responding, the setting is put back exactly as it was and the attempt is reported as failed, so a lost connection is never left for you to trace back to the tweak that caused it. The check opens a TCP connection to 1.1.1.1, or to github.com if that is unreachable, and sends nothing about you or your device.
+
+Select all in Quick Scan no longer ticks the changes the scan advises against on your hardware. Those remain available individually, under their own heading, with the reason shown. Deselect all continues to clear every box.
+
+These tweaks can still suit one line and not another, and neither check measures speed: congestion control only shows itself on a loaded connection, and an idle measurement would move by noise alone. Every change remains reversible from the same place.
+
+Windows application and installer signatures are verified before distribution. Code signing identifies the publisher; Windows may still show reputation warnings.

--- a/backend/legal/PRIVACY.md
+++ b/backend/legal/PRIVACY.md
@@ -1,10 +1,20 @@
 # Privacy Policy
 
-Last updated: 2026-08-24
+Last updated: 2026-09-12
 
 PC Tweaker is a desktop application. Windows tweaks, snapshots, rollback data,
 hardware readings and file scans are processed locally on your device. They are
 not uploaded to PC Tweaker.
+
+## Connection check
+
+The two tweaks that change how Windows handles TCP connections
+(acknowledgment timing and the congestion provider) can affect an unusual
+line in ways the setting alone does not predict. When you apply one, the app
+opens a TCP connection to 1.1.1.1 and, if that is unreachable, to github.com,
+before and after the change, purely to confirm the line still works. If it
+stopped working, the app puts the setting back. No data about you or your
+device is sent in that check.
 
 ## Account data
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pc-tweaker-app",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pc-tweaker-app",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pc-tweaker-app",
   "private": true,
-  "version": "1.13.0",
+  "version": "1.13.1",
   "license": "UNLICENSED",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-app"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-app"
-version = "1.13.0"
+version = "1.13.1"
 description = "Real Windows tweaks with automatic one-click rollback"
 authors = ["Aurelio Avila"]
 license-file = "../LICENSE"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -40,6 +40,7 @@ mod ipc_commands;
 mod ipc_tests;
 mod license;
 mod lifetime_tools;
+mod netcheck;
 mod netlatency;
 mod netmaintenance;
 mod netshaper;
@@ -485,9 +486,24 @@ fn apply_by_id(
     app_data_dir: &std::path::Path,
     id: &str,
 ) -> Result<(), String> {
+    // Read the line before touching it. Without the earlier reading, a
+    // failed probe afterwards cannot be told apart from a machine that was
+    // offline the whole time, and the guard would revert a good tweak on a
+    // PC that never had internet.
+    let was_online = netcheck::relevant(id) && netcheck::online();
+
     // Single funnel for every apply (direct, batched, and the elevated
     // helper), so this one audit call covers them all exactly once.
-    let result = apply_by_id_inner(store, app_data_dir, id);
+    let mut result = apply_by_id_inner(store, app_data_dir, id);
+
+    if result.is_ok() && netcheck::regressed(was_online) {
+        // Reverted through the public funnel so the audit log carries the
+        // revert as its own event, rather than an apply that quietly undid
+        // itself with nothing to show for it.
+        let restored = rollback_by_id(store, id).is_ok();
+        result = Err(netcheck::reverted_message(restored));
+    }
+
     audit::record(
         "tweak-applied",
         id,

--- a/src-tauri/src/netcheck.rs
+++ b/src-tauri/src/netcheck.rs
@@ -1,0 +1,102 @@
+//! Connectivity guard for the two tweaks that change how TCP behaves.
+//!
+//! `netlatency` and `netshaper` are the only changes here whose effect is not
+//! confined to this machine: they alter how Windows talks to everything else,
+//! and on an unusual line — a middlebox that dislikes BBR2's pacing, a driver
+//! that mishandles `TcpAckFrequency` — the outcome genuinely cannot be read
+//! off the setting. Disclosure text does not fix that, because the user
+//! cannot check the claim either.
+//!
+//! What *can* be checked is the case that actually costs something: a line
+//! that worked a second ago and does not work now. That is not a judgement
+//! call, so the apply funnel notices it, puts the setting back on its own and
+//! says so, instead of leaving someone to work out which of the things they
+//! just ticked took their connection away.
+//!
+//! Deliberately not measured: throughput or round-trip time, before against
+//! after. Congestion control only shows itself on a loaded line; an idle
+//! probe would move by noise alone, and reporting noise as evidence is the
+//! move this app exists to refuse.
+
+use std::net::{TcpStream, ToSocketAddrs};
+use std::time::Duration;
+
+/// Endpoints the app already reaches for in normal operation: 1.1.1.1 is what
+/// the DNS tweak writes, github.com is where the updater looks. The literal
+/// address comes first so an online machine answers in milliseconds and never
+/// waits on a resolver; the hostname is the fallback for networks that block
+/// Cloudflare, and doubles as a check that name resolution still works.
+const PROBES: [&str; 2] = ["1.1.1.1:443", "github.com:443"];
+
+/// Short on purpose. This runs before and after an apply the user is waiting
+/// on, and a machine that is simply offline must not be held up for it.
+const TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Whether this tweak changes how the TCP stack behaves, and so is worth
+/// guarding. Nothing else here can take the line down.
+pub fn relevant(id: &str) -> bool {
+    id == crate::netlatency::TWEAK_ID || id == crate::netshaper::TWEAK_ID
+}
+
+/// One pass over the probes. A single reachable endpoint is enough: this asks
+/// "does the line still work", not "is every host on the internet up".
+pub fn online() -> bool {
+    PROBES.iter().any(|probe| {
+        probe.to_socket_addrs().is_ok_and(|addrs| {
+            addrs
+                .take(4)
+                .any(|addr| TcpStream::connect_timeout(&addr, TIMEOUT).is_ok())
+        })
+    })
+}
+
+/// True only when the line was up before the change and is still down on a
+/// second look.
+///
+/// The second look is what stops a Wi-Fi blip from reverting a setting that
+/// was never the problem. `was_online == false` short-circuits before any
+/// socket is opened, so a machine with no internet is never told it just lost
+/// some — and never has a tweak pulled out from under it on that basis.
+pub fn regressed(was_online: bool) -> bool {
+    if !was_online || online() {
+        return false;
+    }
+    std::thread::sleep(Duration::from_millis(500));
+    !online()
+}
+
+/// What the user is told when the guard fires. The apply is reported as
+/// failed, because from where they sit it did fail: they asked for a faster
+/// line and have the one they started with.
+pub fn reverted_message(restored: bool) -> String {
+    if restored {
+        "the connection stopped responding after this change, so it was put back exactly as it was"
+            .to_string()
+    } else {
+        "the connection stopped responding after this change and putting it back failed - use Restore All"
+            .to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The guard must never open a socket, nor revert anything, on a machine
+    /// that had no connectivity to lose. This is the entire reason
+    /// `regressed` takes the earlier reading instead of deciding alone.
+    #[test]
+    fn a_machine_that_was_offline_is_never_reported_as_regressed() {
+        assert!(!regressed(false));
+    }
+
+    /// Guarding anything else would mean two extra network round trips on
+    /// tweaks that cannot affect the network at all.
+    #[test]
+    fn only_the_two_tcp_tweaks_are_guarded() {
+        assert!(relevant(crate::netlatency::TWEAK_ID));
+        assert!(relevant(crate::netshaper::TWEAK_ID));
+        assert!(!relevant(crate::dns::TWEAK_ID));
+        assert!(!relevant("power_plan"));
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "pc-tweaker-app",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "identifier": "com.aurel.pc-tweaker-app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/components/scan.tsx
+++ b/src/components/scan.tsx
@@ -337,6 +337,25 @@ export function ScanPanel({
     }
   }
 
+  /**
+   * The issues "Select all" is allowed to tick: everything except the ones
+   * the hardware argues against or cannot do at all.
+   *
+   * A bulk control that ticks the "not recommended" group turns a screen full
+   * of reasoning into a single sweep, which is the habit this app is supposed
+   * to break — and the verdicts are not decoration: they are what stops High
+   * performance going on a laptop or the search index off an NVMe drive. Both
+   * remain one click away in their own group, individually, on purpose.
+   */
+  const selectableIssues = useMemo(
+    () =>
+      fixableIssues.filter((i) => {
+        const verdict = advice[i.id]?.verdict;
+        return verdict !== "notrecommended" && verdict !== "unsupported";
+      }),
+    [fixableIssues, advice],
+  );
+
   /** Ids the hardware actually argues for, in list order. */
   const recommendedIds = useMemo(
     () => fixableIssues.filter((i) => advice[i.id]?.verdict === "recommended").map((i) => i.id),
@@ -708,16 +727,19 @@ export function ScanPanel({
                 </p>
                 <button
                   onClick={() => {
-                    const allChecked = fixableIssues.every((i) => checked[i.id]);
-                    const next: Record<string, boolean> = {};
-                    fixableIssues.forEach((i) => {
-                      next[i.id] = !allChecked;
-                    });
+                    const allChecked = selectableIssues.every((i) => checked[i.id]);
+                    // Clearing covers every row, selecting only the ones that
+                    // survive the verdicts: "deselect all" that left a box
+                    // ticked would be a lie about what is about to be applied.
+                    const next: Record<string, boolean> = Object.fromEntries(
+                      fixableIssues.map((i) => [i.id, false]),
+                    );
+                    if (!allChecked) selectableIssues.forEach((i) => (next[i.id] = true));
                     setChecked(next);
                   }}
                   className="text-xs text-ink-3 hover:text-ink-2"
                 >
-                  {fixableIssues.every((i) => checked[i.id])
+                  {selectableIssues.every((i) => checked[i.id])
                     ? s.scan.deselectAll
                     : s.scan.selectAll}
                 </button>


### PR DESCRIPTION
Answers two of the five points in the FileCroco review's "the not so good" section. The other three were left alone on purpose.

## Connection guard on the two TCP tweaks

`netlatency` (acknowledgment timing) and `netshaper` (BBR2 congestion provider) are the only changes whose effect leaves this machine, and on an unusual line the outcome genuinely cannot be read off the setting. The new `netcheck` module reads the line before the change, looks again afterwards, and on a second failed look reverts through the public rollback path and reports the apply as failed. A machine that was already offline short-circuits before any socket opens.

Throughput and round-trip time are deliberately not measured: congestion control only shows itself on a loaded line, and an idle probe would move by noise alone.

## Select all no longer sweeps the discouraged group

In Quick Scan it ticked every row including the ones the hardware verdicts argue against. It now covers only what survives the verdicts; Deselect all still clears every box.

## Privacy

The check opens a TCP connection to 1.1.1.1, or github.com when that is unreachable, and sends nothing about the user or the device. Both copies of the policy say so and the date is bumped.

## Checks

`npm run check` (TypeScript, eslint, prettier, i18n coverage and quality, 304 Rust tests, advisor, thermals, updater), native policy, release verification, 111 backend tests, site build. All green.

## Not done here

Steps 4 to 9 of RELEASING.md. The signed local build, the updater signature, `latest.json`, the tag, the GitHub release and therefore the winget submission all need the code-signing certificate and the Tauri updater private key.