### PR TITLE
Link directly to canonical support URL

### DIFF
--- a/site/src/components/Nav.tsx
+++ b/site/src/components/Nav.tsx
@@ -44,7 +44,7 @@ export function Nav({
             </a>
           ))}
           <Link
-            to="/support"
+            to="/support/"
             onNavigate={navigate}
             className="hidden text-[13.5px] font-medium text-[var(--fg-dim)] transition-colors hover:text-[var(--fg)] md:block"
           >


### PR DESCRIPTION
Change only the main navigation support destination to /support/. Route keys and all application assets remain unchanged. Production build and SEO checks passed for 14 sitemap routes and the 404 page.