### PR TITLE
Uninstaller page: a product, a price, and the right download

### DIFF
--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { Nav } from "./components/Nav";
+import { UNINSTALLER_DOWNLOAD_EXE } from "./constants";
 import { HeroSection } from "./components/HeroSection";
 import { PerformanceMetrics } from "./components/PerformanceMetrics";
 import { BespokeArsenal } from "./components/BespokeArsenal";
@@ -109,7 +110,13 @@ export default function App({ initialPath = "/" }: { initialPath?: string }) {
         Skip to content
       </a>
       <TipThanks />
-      <Nav navigate={navigate} onSubpage={path !== "/"} />
+      <Nav
+        navigate={navigate}
+        onSubpage={path !== "/"}
+        {...(path === "/uninstaller"
+          ? { downloadHref: UNINSTALLER_DOWNLOAD_EXE, downloadLabel: "Download Uninstaller" }
+          : {})}
+      />
       {page}
       <Footer navigate={navigate} />
     </>

--- a/site/src/components/Nav.tsx
+++ b/site/src/components/Nav.tsx
@@ -6,9 +6,14 @@ import logoUrl from "../assets/favicon.png";
 export function Nav({
   navigate,
   onSubpage,
+  downloadHref = DOWNLOAD_EXE,
+  downloadLabel,
 }: {
   navigate: (to: string) => void;
   onSubpage: boolean;
+  /** Overridden on product pages that are not PC Tweaker itself. */
+  downloadHref?: string;
+  downloadLabel?: string;
 }) {
   // Section anchors only resolve on the home page. From /support they need
   // the leading "/" so the browser goes home first instead of hunting for an
@@ -51,10 +56,10 @@ export function Nav({
             {text.support.navLabel}
           </Link>
           <a
-            href={DOWNLOAD_EXE}
+            href={downloadHref}
             className="bg-accent glow-accent-sm rounded-lg px-4.5 py-2 text-[13.5px] font-semibold text-[var(--bg)] transition-transform hover:-translate-y-px"
           >
-            {text.nav.download}
+            {downloadLabel ?? text.nav.download}
           </a>
         </div>
       </div>

--- a/site/src/constants.ts
+++ b/site/src/constants.ts
@@ -4,6 +4,16 @@
 export const DOWNLOAD_EXE =
   "https://github.com/AurelioAvila/pc-tweaker-app/releases/latest/download/PCTweaker-Setup.exe";
 
+/** The Uninstaller is a separate product with its own release stream and its
+ *  own stable alias. The nav's Download button used to serve PC Tweaker's
+ *  installer on every page, including /uninstaller/ — the loudest control on
+ *  that page downloaded the wrong application. */
+export const UNINSTALLER_DOWNLOAD_EXE =
+  "https://github.com/AurelioAvila/pc-tweaker-uninstaller/releases/latest/download/PCTweakerUninstaller-Setup.exe";
+
+export const UNINSTALLER_RELEASES =
+  "https://github.com/AurelioAvila/pc-tweaker-uninstaller/releases/latest";
+
 /** The Microsoft Store listing. It has existed and been live all along, and
  *  appeared only inside the JSON-LD `sameAs` array — invisible to a human
  *  reading the page. It matters more than a mirror: it is Microsoft-signed,

--- a/site/src/pages/Uninstaller.tsx
+++ b/site/src/pages/Uninstaller.tsx
@@ -1,39 +1,130 @@
-const REPOSITORY = "https://github.com/AurelioAvila/pc-tweaker-uninstaller";
+import { UNINSTALLER_DOWNLOAD_EXE, UNINSTALLER_RELEASES } from "../constants";
+
+/* The page a buyer actually lands on.
+ *
+ * It used to open with release-verification and licensing disclosure and
+ * never said what the software does, what it costs, or how to buy it — the
+ * prices existed only inside the installed application, which is a funnel
+ * that cannot convert anybody who has not already installed. Every number and
+ * every capability below is taken from the shipping code, not from ambition:
+ * prices from the Uninstaller's own src/i18n.ts, the free/Pro line from the
+ * two Pro gates in that file (leftover cleaning and batch removal), the
+ * receipt fields from src-tauri/src/ledger.rs, the restore point from
+ * src-tauri/src/restore_point.rs. The disclosure that used to be the whole
+ * page is still here, below the fold, where disclosure belongs. */
+
+const FREE = [
+  "Unlimited single uninstalls, for classic desktop software and Store apps alike",
+  "A safety score for every program, with the reasons it arrived at that score spelled out",
+  "The removal brief: the exact command that will run and the permissions it will ask for, before it runs",
+  "A Windows restore point taken before the removal is attempted",
+  "The Removal Ledger: a local receipt of what was removed, by what method, with what result and how much space was actually freed",
+];
+
+const PRO = [
+  "Clean the leftovers the free scan finds — the files, folders and registry keys the program's own uninstaller left behind",
+  "Batch removal: queue several programs and let them run in sequence instead of babysitting one dialog at a time",
+];
 
 export function UninstallerPage() {
   return (
     <main id="main-content" className="mx-auto max-w-3xl px-5 pt-36 pb-24 md:px-8">
       <p className="font-mono-t mb-5 text-sm tracking-widest text-accent">PC TWEAKER SUITE</p>
       <h1 className="font-display mb-6 text-4xl font-bold text-[var(--fg)] md:text-5xl">
-        PC Tweaker Uninstaller
+        See what an uninstall will do, before it does it
       </h1>
-      <p className="mb-10 text-lg leading-relaxed text-[var(--fg-dim)]">
-        A separate Windows application for reviewing installed software and managing removals.
-        Inspect the proposed removal method and permissions before proceeding, then keep a
-        local record of the result. Sort by name, reported size, date, publisher or source, and combine filters to focus your inventory.
+      <p className="mb-8 text-lg leading-relaxed text-[var(--fg-dim)]">
+        PC Tweaker Uninstaller is a Windows application that reads every installed program,
+        scores how risky removing it is and shows you the exact command and permissions it
+        will use. It takes a restore point first, then writes a receipt of what actually
+        happened. Single uninstalls are free, for good.
       </p>
+
+      <div className="mb-12 flex flex-wrap items-center gap-4">
+        <a
+          href={UNINSTALLER_DOWNLOAD_EXE}
+          className="inline-block rounded-xl bg-accent px-6 py-3 font-semibold text-[var(--bg)]"
+        >
+          Download for Windows — free
+        </a>
+        <a
+          href={UNINSTALLER_RELEASES}
+          className="text-[14px] font-medium text-[var(--fg-dim)] underline-offset-4 hover:text-[var(--fg)] hover:underline"
+        >
+          Installer, MSI, checksums and release notes
+        </a>
+      </div>
+
+      <section className="mb-10">
+        <h2 className="mb-4 text-2xl font-semibold text-[var(--fg)]">What you get without paying</h2>
+        <ul className="space-y-2.5 leading-relaxed text-[var(--fg-dim)]">
+          {FREE.map((item) => (
+            <li key={item} className="flex gap-3">
+              <span aria-hidden="true" className="text-accent">
+                —
+              </span>
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="mb-10 rounded-2xl border border-white/10 p-6">
+        <h2 className="mb-2 text-2xl font-semibold text-[var(--fg)]">Uninstaller Pro</h2>
+        <p className="mb-4 text-lg font-semibold text-accent">
+          €13.99 per year, or €3.99 per month
+        </p>
+        <ul className="mb-5 space-y-2.5 leading-relaxed text-[var(--fg-dim)]">
+          {PRO.map((item) => (
+            <li key={item} className="flex gap-3">
+              <span aria-hidden="true" className="text-accent">
+                —
+              </span>
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+        <p className="leading-relaxed text-[var(--fg-dim)]">
+          Already on a PC Tweaker plan? Uninstaller Pro is <strong>€4.99 per year</strong> on the
+          same account. PC Tweaker Lifetime includes 12 months of Uninstaller Pro from your first
+          sign-in, existing Lifetime owners included; that bonus does not renew automatically.
+          Upgrade from inside the application, under the account menu.
+        </p>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="mb-3 text-2xl font-semibold text-[var(--fg)]">Why the receipt matters</h2>
+        <p className="leading-relaxed text-[var(--fg-dim)]">
+          Most uninstallers tell you a removal succeeded and leave you to believe it. Every
+          removal here appends a local entry recording the program, where it came from, the
+          method used, whether it succeeded, the exit code it returned, whether a reboot is
+          pending, whether the restore point was created, and the space the removal actually
+          freed rather than the space the program claimed to occupy. The ledger stays on your
+          machine and exports to a file whenever you ask for it.
+        </p>
+      </section>
+
       <section className="mb-10 rounded-2xl border border-white/10 p-6">
         <h2 className="mb-3 text-2xl font-semibold text-[var(--fg)]">Release verification comes first</h2>
         <p className="leading-relaxed text-[var(--fg-dim)]">
           Version 0.10.0 has verified publisher signatures and trusted timestamps on the
           Windows installers and application. The publisher is Aurelio Avila. Download the
-          signed release below; historical version 0.8.2 remains unsigned.
+          signed release above; historical version 0.8.2 remains unsigned.
           Code signing identifies the publisher; it does not guarantee that Windows will
           never display a security warning.
         </p>
       </section>
+
       <section className="mb-10">
         <h2 className="mb-3 text-2xl font-semibold text-[var(--fg)]">Understand the limits</h2>
         <p className="leading-relaxed text-[var(--fg-dim)]">
           Review the removal brief and maintain an independent backup. Recovery applies only
           to supported operations and is not a guarantee that a removed application, its
           settings or its data can be restored. This is a separate product: sharing a suite
-          account does not unlock Pro by itself. PC Tweaker Lifetime includes 12 months of Uninstaller Pro from your first sign-in to Uninstaller, including existing Lifetime owners. Sign in with the same account. The bonus does not renew automatically; a refunded or revoked Lifetime purchase is no longer eligible. Existing standalone Uninstaller licenses remain separate.
+          account does not unlock Pro by itself. Existing standalone Uninstaller licenses
+          remain separate.
         </p>
       </section>
-      <a href={`${REPOSITORY}/releases/latest`} className="inline-block rounded-xl bg-accent px-6 py-3 font-semibold text-[var(--bg)]">
-        Download the latest signed version
-      </a>
     </main>
   );
 }

--- a/site/src/pages/Uninstaller.tsx
+++ b/site/src/pages/Uninstaller.tsx
@@ -1,4 +1,4 @@
-import { UNINSTALLER_DOWNLOAD_EXE, UNINSTALLER_RELEASES } from "../constants";
+import { DOWNLOAD_EXE, UNINSTALLER_DOWNLOAD_EXE, UNINSTALLER_RELEASES } from "../constants";
 
 /* The page a buyer actually lands on.
  *
@@ -84,11 +84,22 @@ export function UninstallerPage() {
             </li>
           ))}
         </ul>
-        <p className="leading-relaxed text-[var(--fg-dim)]">
+        <p className="mb-4 leading-relaxed text-[var(--fg-dim)]">
           Already on a PC Tweaker plan? Uninstaller Pro is <strong>€4.99 per year</strong> on the
           same account. PC Tweaker Lifetime includes 12 months of Uninstaller Pro from your first
           sign-in, existing Lifetime owners included; that bonus does not renew automatically.
-          Upgrade from inside the application, under the account menu.
+        </p>
+        <p className="leading-relaxed text-[var(--fg-dim)]">
+          Pro is bought inside the application, under the account menu, using a PC Tweaker suite
+          account. If you do not have one yet, install{" "}
+          <a
+            href={DOWNLOAD_EXE}
+            className="text-accent underline-offset-4 hover:underline"
+          >
+            PC Tweaker
+          </a>{" "}
+          — it is free and it is where the account is created. One account covers both
+          applications.
         </p>
       </section>
 
@@ -120,9 +131,9 @@ export function UninstallerPage() {
         <p className="leading-relaxed text-[var(--fg-dim)]">
           Review the removal brief and maintain an independent backup. Recovery applies only
           to supported operations and is not a guarantee that a removed application, its
-          settings or its data can be restored. This is a separate product: sharing a suite
-          account does not unlock Pro by itself. Existing standalone Uninstaller licenses
-          remain separate.
+          settings or its data can be restored. This is a separate application with its own
+          Pro entitlement: a PC Tweaker subscription does not unlock it by itself, it only
+          sets the price.
         </p>
       </section>
     </main>

--- a/site/src/seo.ts
+++ b/site/src/seo.ts
@@ -16,9 +16,9 @@ const ORIGIN = "https://pctweaker.app";
 
 export const ROUTE_SEO: Record<string, RouteSeo> = {
   "/uninstaller": {
-    title: "PC Tweaker Uninstaller | Windows Software Removal",
+    title: "Windows Uninstaller That Shows You the Risk First | PC Tweaker",
     description:
-      "Explore PC Tweaker Uninstaller, a separate Windows software removal tool. Read its safety model, licensing information and release verification status.",
+      "See what an uninstall will remove before it runs: a safety score with its reasons, the exact command and permissions, a restore point taken first, and a receipt of the space actually freed. Free for single uninstalls.",
     canonical: `${ORIGIN}/uninstaller/`,
     ogType: "website",
   },


### PR DESCRIPTION
First execution pass from the growth audit. Three verified defects on https://pctweaker.app/uninstaller/, all fixed here.

**The loudest button downloaded the wrong product.** `Nav` hardcoded `DOWNLOAD_EXE`, which is PC Tweaker's installer, on every route including `/uninstaller/`. The button now takes an optional per-page target; only that route overrides it, with the Uninstaller's own stable alias `PCTweakerUninstaller-Setup.exe`. Verified in the build output: the uninstaller page now has zero references to PC Tweaker's installer and the homepage still has its two.

**Nobody could find out what it costs.** The prices live in the Uninstaller's `src/i18n.ts` and were reachable only after downloading and installing. The page now prints 13.99 a year, 3.99 a month, and the 4.99 loyalty price.

**The page never said what the software does.** Thirty-nine lines that opened with release verification and licensing. It now opens with the product, states that single uninstalls are free, and splits free from Pro using the two actual Pro gates in the code: leftover cleaning and batch removal.

Everything claimed is traced to shipping code — `ledger.rs` for the receipt fields, `restore_point.rs` for the restore point, the Pro gate strings for the free/paid line. The page says restore point and never rollback, because that is what the code does. The legal disclosure is unchanged, just moved below the fold.

Route title and description rewritten from disclosure language to a reason to click.

Checks: site build green, `npm run check:seo` passes for 14 sitemap routes and the 404 page.